### PR TITLE
implement identity cookies

### DIFF
--- a/idp/idp.go
+++ b/idp/idp.go
@@ -20,7 +20,7 @@ import (
 type DischargeTokenCreator interface {
 	// DischargeToken creates a new httpbakery.DischargeToken for the
 	// given identity.
-	DischargeToken(ctx context.Context, dischargeID string, id *store.Identity) (*httpbakery.DischargeToken, error)
+	DischargeToken(ctx context.Context, id *store.Identity) (*httpbakery.DischargeToken, error)
 }
 
 // A VisitCompleter is used by the identity providers to finish login

--- a/idp/idptest/suite.go
+++ b/idp/idptest/suite.go
@@ -147,7 +147,7 @@ func (l *visitCompleter) Failure(_ context.Context, _ http.ResponseWriter, _ *ht
 
 type dischargeTokenCreator struct{}
 
-func (d *dischargeTokenCreator) DischargeToken(_ context.Context, _ string, id *store.Identity) (*httpbakery.DischargeToken, error) {
+func (d *dischargeTokenCreator) DischargeToken(_ context.Context, id *store.Identity) (*httpbakery.DischargeToken, error) {
 	return &httpbakery.DischargeToken{
 		Kind:  "test",
 		Value: []byte(id.Username),

--- a/idp/keystone/token.go
+++ b/idp/keystone/token.go
@@ -67,7 +67,7 @@ func (idp *tokenIdentityProvider) Handle(ctx context.Context, w http.ResponseWri
 		return
 	}
 	if strings.TrimPrefix(req.URL.Path, idp.initParams.URLPrefix) == "/interact" {
-		dt, err := idp.initParams.DischargeTokenCreator.DischargeToken(ctx, idputil.DischargeID(req), user)
+		dt, err := idp.initParams.DischargeTokenCreator.DischargeToken(ctx, user)
 		if err != nil {
 			idp.initParams.VisitCompleter.Failure(ctx, w, req, idputil.DischargeID(req), err)
 			return

--- a/idp/keystone/tokenv3.go
+++ b/idp/keystone/tokenv3.go
@@ -63,7 +63,7 @@ func (idp *v3tokenIdentityProvider) Handle(ctx context.Context, w http.ResponseW
 		return
 	}
 	if strings.TrimPrefix(req.URL.Path, idp.initParams.URLPrefix) == "/interact" {
-		dt, err := idp.initParams.DischargeTokenCreator.DischargeToken(ctx, idputil.DischargeID(req), user)
+		dt, err := idp.initParams.DischargeTokenCreator.DischargeToken(ctx, user)
 		if err != nil {
 			idp.initParams.VisitCompleter.Failure(ctx, w, req, idputil.DischargeID(req), err)
 			return

--- a/idp/keystone/userpass.go
+++ b/idp/keystone/userpass.go
@@ -83,7 +83,7 @@ func (idp *userpassIdentityProvider) Handle(ctx context.Context, w http.Response
 		return
 	}
 	if strings.TrimPrefix(req.URL.Path, idp.initParams.URLPrefix) == "/interact" {
-		dt, err := idp.initParams.DischargeTokenCreator.DischargeToken(ctx, idputil.DischargeID(req), user)
+		dt, err := idp.initParams.DischargeTokenCreator.DischargeToken(ctx, user)
 		if err != nil {
 			idp.initParams.VisitCompleter.Failure(ctx, w, req, idputil.DischargeID(req), err)
 			return

--- a/idp/test/test.go
+++ b/idp/test/test.go
@@ -160,7 +160,7 @@ func (idp *identityProvider) handlePost(ctx context.Context, w http.ResponseWrit
 	default:
 		return nil, errgo.WithCausef(nil, params.ErrNotFound, "path %q not found", req.URL.Path)
 	case "/interact":
-		dt, err := idp.initParams.DischargeTokenCreator.DischargeToken(ctx, idputil.DischargeID(req), &id)
+		dt, err := idp.initParams.DischargeTokenCreator.DischargeToken(ctx, &id)
 		if err != nil {
 			return nil, errgo.Mask(err)
 		}

--- a/idp/usso/ussodischarge/ussodischarge.go
+++ b/idp/usso/ussodischarge/ussodischarge.go
@@ -255,7 +255,7 @@ func (idp identityProvider) handleInteract(ctx context.Context, w http.ResponseW
 		if err != nil {
 			return err
 		}
-		token, err := idp.initParams.DischargeTokenCreator.DischargeToken(ctx, idputil.DischargeID(req), user)
+		token, err := idp.initParams.DischargeTokenCreator.DischargeToken(ctx, user)
 		if err != nil {
 			return err
 		}

--- a/idp/usso/ussooauth/ussooauth.go
+++ b/idp/usso/ussooauth/ussooauth.go
@@ -105,7 +105,7 @@ func (idp *identityProvider) Handle(ctx context.Context, w http.ResponseWriter, 
 		return
 	}
 	if strings.TrimPrefix(req.URL.Path, idp.initParams.URLPrefix) == "/interact" {
-		token, err := idp.initParams.DischargeTokenCreator.DischargeToken(ctx, idputil.DischargeID(req), &identity)
+		token, err := idp.initParams.DischargeTokenCreator.DischargeToken(ctx, &identity)
 		if err != nil {
 			code, body := httpbakery.ErrorToResponse(ctx, err)
 			httprequest.WriteJSON(w, code, body)

--- a/internal/discharger/api.go
+++ b/internal/discharger/api.go
@@ -31,7 +31,7 @@ func NewAPIHandler(params identity.HandlerParams) ([]httprequest.Handler, error)
 	vc := &visitCompleter{
 		params:                params,
 		dischargeTokenCreator: dt,
-		place:                 place,
+		place: place,
 	}
 	if err := initIDPs(context.Background(), params, dt, vc); err != nil {
 		return nil, errgo.Mask(err)

--- a/internal/discharger/discharge_test.go
+++ b/internal/discharger/discharge_test.go
@@ -197,7 +197,7 @@ func (t *responseBodyRecordingTransport) RoundTrip(req *http.Request) (*http.Res
 }
 
 func (s *dischargeSuite) TestDischargeFromDifferentOriginWhenLoggedIn(c *gc.C) {
-	c.Skip("cookies not yet supported")
+	c.Skip("origin caveats on identity cookies not yet supported")
 	var disabled bool
 	openWebBrowser := func(u *url.URL) error {
 		if disabled {
@@ -548,9 +548,7 @@ func (s *dischargeSuite) TestPublicKey(c *gc.C) {
 	})
 }
 
-// TODO(mhilton): Work out how to deal with identity cookies later.
 func (s *dischargeSuite) TestIdentityCookieParameters(c *gc.C) {
-	c.Skip("cookies not yet supported")
 	client := s.Client(webBrowserInteractor)
 	jar := new(testCookieJar)
 	client.Client.Jar = jar

--- a/internal/discharger/export_test.go
+++ b/internal/discharger/export_test.go
@@ -16,6 +16,6 @@ func NewVisitCompleter(params identity.HandlerParams) idp.VisitCompleter {
 	return &visitCompleter{
 		params:                params,
 		dischargeTokenCreator: &dischargeTokenCreator{params: params},
-		place:                 &place{params.MeetingPlace},
+		place: &place{params.MeetingPlace},
 	}
 }


### PR DESCRIPTION
We remove the strong association between a discharge token and the
specific discharge it's being used for and instead treat it as a
something that's reusable for subsequent discharge requests.

As such, we also return it as a cookie.