### PR TITLE
cmd/candid: rename put-agent to create-agent

### DIFF
--- a/cmd/candid/internal/admincmd/create-agent.go
+++ b/cmd/candid/internal/admincmd/create-agent.go
@@ -19,7 +19,7 @@ import (
 	"github.com/CanonicalLtd/candid/internal/auth"
 )
 
-type putAgentCommand struct {
+type createAgentCommand struct {
 	candidCommand
 	groups        []string
 	agentFile     string
@@ -28,12 +28,12 @@ type putAgentCommand struct {
 	publicKey     *bakery.PublicKey
 }
 
-func newPutAgentCommand() cmd.Command {
-	return &putAgentCommand{}
+func newCreateAgentCommand() cmd.Command {
+	return &createAgentCommand{}
 }
 
-var putAgentDoc = `
-The put-agent command creates or updates an agent user on the Candid
+var createAgentDoc = `
+The create-agent command creates an agent user on the Candid
 server.
 
 An agent user has an associated public key - the private key pair can
@@ -57,16 +57,16 @@ printed to the standard output. Note when the -k flag is specified,
 this information will be missing the private key.
 `
 
-func (c *putAgentCommand) Info() *cmd.Info {
+func (c *createAgentCommand) Info() *cmd.Info {
 	return &cmd.Info{
-		Name:    "put-agent",
+		Name:    "create-agent",
 		Args:    "[group...]",
 		Purpose: "create or update an agent user",
-		Doc:     putAgentDoc,
+		Doc:     createAgentDoc,
 	}
 }
 
-func (c *putAgentCommand) SetFlags(f *gnuflag.FlagSet) {
+func (c *createAgentCommand) SetFlags(f *gnuflag.FlagSet) {
 	c.candidCommand.SetFlags(f)
 	publicKeyVar(f, &c.publicKey, "k", "public key of agent")
 	publicKeyVar(f, &c.publicKey, "public-key", "")
@@ -76,7 +76,7 @@ func (c *putAgentCommand) SetFlags(f *gnuflag.FlagSet) {
 	f.StringVar(&c.agentFullName, "name", "", "name of agent")
 }
 
-func (c *putAgentCommand) Init(args []string) error {
+func (c *createAgentCommand) Init(args []string) error {
 	c.groups = args
 	if c.agentFile != "" && c.publicKey != nil {
 		return errgo.Newf("cannot specify public key and an agent file")
@@ -84,7 +84,7 @@ func (c *putAgentCommand) Init(args []string) error {
 	return errgo.Mask(c.candidCommand.Init(nil))
 }
 
-func (c *putAgentCommand) Run(cmdctx *cmd.Context) error {
+func (c *createAgentCommand) Run(cmdctx *cmd.Context) error {
 	ctx := context.Background()
 	client, err := c.Client(cmdctx)
 	if err != nil {

--- a/cmd/candid/internal/admincmd/create-agent_test.go
+++ b/cmd/candid/internal/admincmd/create-agent_test.go
@@ -16,13 +16,13 @@ import (
 	"github.com/CanonicalLtd/candid/cmd/candid/internal/admincmd"
 )
 
-type putAgentSuite struct {
+type createAgentSuite struct {
 	commandSuite
 }
 
-var _ = gc.Suite(&putAgentSuite{})
+var _ = gc.Suite(&createAgentSuite{})
 
-var putAgentUsageTests = []struct {
+var createAgentUsageTests = []struct {
 	about       string
 	args        []string
 	expectError string
@@ -40,14 +40,14 @@ var putAgentUsageTests = []struct {
 	expectError: `invalid value "xxx" for flag -k: wrong length for key, got 2 want 32`,
 }}
 
-func (s *putAgentSuite) TestUsage(c *gc.C) {
-	for i, test := range putAgentUsageTests {
+func (s *createAgentSuite) TestUsage(c *gc.C) {
+	for i, test := range createAgentUsageTests {
 		c.Logf("test %d: %v", i, test.about)
-		CheckError(c, 2, test.expectError, s.Run, append([]string{"put-agent"}, test.args...)...)
+		CheckError(c, 2, test.expectError, s.Run, append([]string{"create-agent"}, test.args...)...)
 	}
 }
 
-func (s *putAgentSuite) TestPutAgentWithGeneratedKeyAndAgentFileNotSpecified(c *gc.C) {
+func (s *createAgentSuite) TestCreateAgentWithGeneratedKeyAndAgentFileNotSpecified(c *gc.C) {
 	var calledReq *params.CreateAgentRequest
 	runf := s.RunServer(c, &handler{
 		createAgent: func(req *params.CreateAgentRequest) (*params.CreateAgentResponse, error) {
@@ -57,7 +57,7 @@ func (s *putAgentSuite) TestPutAgentWithGeneratedKeyAndAgentFileNotSpecified(c *
 			}, nil
 		},
 	})
-	out := CheckSuccess(c, runf, "put-agent", "--name", "agentname", "-a", "admin.agent")
+	out := CheckSuccess(c, runf, "create-agent", "--name", "agentname", "-a", "admin.agent")
 	c.Assert(calledReq, gc.NotNil)
 	// The output should be valid input to an agent.Visitor unmarshal.
 	var v agent.AuthInfo
@@ -80,7 +80,7 @@ func (s *putAgentSuite) TestPutAgentWithGeneratedKeyAndAgentFileNotSpecified(c *
 	})
 }
 
-func (s *putAgentSuite) TestPutAgentWithNonExistentAgentsFileSpecified(c *gc.C) {
+func (s *createAgentSuite) TestCreateAgentWithNonExistentAgentsFileSpecified(c *gc.C) {
 	var calledReq *params.CreateAgentRequest
 	runf := s.RunServer(c, &handler{
 		createAgent: func(req *params.CreateAgentRequest) (*params.CreateAgentResponse, error) {
@@ -91,7 +91,7 @@ func (s *putAgentSuite) TestPutAgentWithNonExistentAgentsFileSpecified(c *gc.C) 
 		},
 	})
 	agentFile := filepath.Join(c.MkDir(), ".agents")
-	out := CheckSuccess(c, runf, "put-agent", "-a", "admin.agent", "-f", agentFile)
+	out := CheckSuccess(c, runf, "create-agent", "-a", "admin.agent", "-f", agentFile)
 	c.Assert(calledReq, gc.NotNil)
 	c.Assert(out, gc.Matches, `added agent a-foo@candid for https://.* to .+\n`)
 
@@ -111,7 +111,7 @@ func (s *putAgentSuite) TestPutAgentWithNonExistentAgentsFileSpecified(c *gc.C) 
 	})
 }
 
-func (s *putAgentSuite) TestPutAgentWithExistingAgentsFile(c *gc.C) {
+func (s *createAgentSuite) TestCreateAgentWithExistingAgentsFile(c *gc.C) {
 	var calledReq *params.CreateAgentRequest
 	runf := s.RunServer(c, &handler{
 		createAgent: func(req *params.CreateAgentRequest) (*params.CreateAgentResponse, error) {
@@ -121,7 +121,7 @@ func (s *putAgentSuite) TestPutAgentWithExistingAgentsFile(c *gc.C) {
 			}, nil
 		},
 	})
-	out := CheckSuccess(c, runf, "put-agent", "-a", "admin.agent", "-f", "admin.agent", "somegroup")
+	out := CheckSuccess(c, runf, "create-agent", "-a", "admin.agent", "-f", "admin.agent", "somegroup")
 	c.Assert(calledReq, gc.NotNil)
 	c.Assert(out, gc.Matches, `added agent a-foo@candid for https://.* to .+\n`)
 
@@ -143,9 +143,9 @@ func (s *putAgentSuite) TestPutAgentWithExistingAgentsFile(c *gc.C) {
 	})
 }
 
-func (s *putAgentSuite) TestPutAgentWithAdminFlag(c *gc.C) {
+func (s *createAgentSuite) TestCreateAgentWithAdminFlag(c *gc.C) {
 	// With the -n flag, it doesn't contact the candid server at all.
-	out := CheckSuccess(c, s.Run, "put-agent", "--admin")
+	out := CheckSuccess(c, s.Run, "create-agent", "--admin")
 	var v agent.AuthInfo
 	err := json.Unmarshal([]byte(out), &v)
 	c.Assert(err, gc.Equals, nil)

--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -16,7 +16,7 @@ github.com/juju/persistent-cookiejar	git	d67418f14c93a698e37b52468958d5d4dcf8a7d
 github.com/juju/postgrestest	git	95c1ddb2775d334cd3011baf1639f72ee497a288	2018-01-11T15:03:07Z
 github.com/juju/retry	git	62c62032529169c7ec02fa48f93349604c345e1f	2015-10-29T02:48:21Z
 github.com/juju/schema	git	075de04f9b7d7580d60a1e12a0b3f50bb18e6998	2016-04-20T04:42:03Z
-github.com/juju/testing	git	43f926548f91d55be6bae26ecb7d2386c64e887c	2018-02-13T13:46:16Z
+github.com/juju/testing	git	44801989f0f7f280bd16b58e898ba9337807f147	2018-04-02T13:06:37Z
 github.com/juju/usso	git	5b79b358f4bb6735c1b00f6ad051c07c1a1a03e9	2016-04-18T12:10:39Z
 github.com/juju/utils	git	4d9b38694f1e441c16421e2320f2b2fbd97fa597	2017-11-22T09:36:53Z
 github.com/juju/version	git	1f41e27e54f21acccf9b2dddae063a782a8a7ceb	2016-10-31T05:19:06Z
@@ -48,7 +48,7 @@ gopkg.in/httprequest.v1	git	3531529dedf047a744dd77f5262515aefff8cd48	2018-03-19T
 gopkg.in/juju/environschema.v1	git	7359fc7857abe2b11b5b3e23811a9c64cb6b01e0	2015-11-04T11:58:10Z
 gopkg.in/juju/names.v2	git	54f00845ae470a362430a966fe17f35f8784ac92	2017-11-13T11:20:47Z
 gopkg.in/ldap.v2	git	8168ee085ee43257585e50c6441aadf54ecb2c9f	2016-12-01T20:47:33Z
-gopkg.in/macaroon-bakery.v2	git	4e2cb21b624f89ea96bc8fba6f1e9696aa8f99fd	2018-03-23T17:42:21Z
+gopkg.in/macaroon-bakery.v2	git	a0743b6619d68bbf8dc5cabbb49738b846f06080	2018-04-23T13:37:35Z
 gopkg.in/macaroon.v2	git	bed2a428da6e56d950bed5b41fcbae3141e5b0d0	2017-10-17T15:30:37Z
 gopkg.in/mgo.v2	git	3f83fa5005286a7fe593b055f0d7771a7dce4655	2016-08-18T02:01:20Z
 gopkg.in/natefinch/lumberjack.v2	git	df99d62fd42d8b3752c8a42c6723555372c02a03	2017-05-31T18:08:50Z


### PR DESCRIPTION
This command now only creates agents - it does not update them.

Also enable environment-variable-based agent-authentication
for all candid commands.