### PR TITLE
internal/discharger: use random discharge ids

### DIFF
--- a/internal/auth/checkers.go
+++ b/internal/auth/checkers.go
@@ -20,7 +20,6 @@ import (
 const (
 	checkersNamespace         = "jujucharms.com/identity"
 	userHasPublicKeyCondition = "user-has-public-key"
-	dischargeIDCondition      = "for-discharge-id"
 )
 
 // Namespace contains the checkers.Namespace supported by the identity
@@ -35,7 +34,6 @@ func NewChecker(a *Authorizer) *checkers.Checker {
 	checker := httpbakery.NewChecker()
 	checker.Namespace().Register(checkersNamespace, "")
 	checker.Register(userHasPublicKeyCondition, checkersNamespace, a.checkUserHasPublicKey)
-	checker.Register(dischargeIDCondition, checkersNamespace, checkDischargeID)
 	return checker
 }
 
@@ -73,20 +71,4 @@ func (a *Authorizer) checkUserHasPublicKey(ctx context.Context, cond, arg string
 		}
 	}
 	return errgo.Newf("public key not valid for user")
-}
-
-// DischargeIDCaveat creates a first-party caveat that ensures that a
-// specific discharge is being performed.
-func DischargeIDCaveat(dischargeID string) checkers.Caveat {
-	return checkers.Caveat{
-		Namespace: checkersNamespace,
-		Condition: checkers.Condition(dischargeIDCondition, dischargeID),
-	}
-}
-
-func checkDischargeID(ctx context.Context, cond, arg string) error {
-	if dischargeIDFromContext(ctx) == arg {
-		return nil
-	}
-	return errgo.Newf("invalid discharge ID")
 }

--- a/internal/discharger/login_test.go
+++ b/internal/discharger/login_test.go
@@ -38,7 +38,7 @@ func (s *loginSuite) SetUpTest(c *gc.C) {
 	s.apiSuite.SetUpTest(c)
 }
 
-func (s *loginSuite) TestInteractiveLogin(c *gc.C) {
+func (s *loginSuite) TestLegacyInteractiveLogin(c *gc.C) {
 	jar := &testCookieJar{}
 	client := httpbakery.NewClient()
 	visitor := test.Interactor{
@@ -90,7 +90,7 @@ func (s *loginSuite) TestNonInteractiveLogin(c *gc.C) {
 	c.Assert(id.LastLogin.After(time.Now().Add(-1*time.Second)), gc.Equals, true)
 }
 
-func (s *loginSuite) TestLoginFailure(c *gc.C) {
+func (s *loginSuite) TestLegacyLoginFailure(c *gc.C) {
 	jar := &testCookieJar{}
 	client := httpbakery.NewClient()
 	visitor := test.Interactor{

--- a/store/memstore/meeting.go
+++ b/store/memstore/meeting.go
@@ -46,6 +46,9 @@ func (s *meetingStore) Put(ctx context.Context, id, address string) error {
 func (s *meetingStore) put(_ context.Context, id, address string, now time.Time) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if _, ok := s.data[id]; ok {
+		return errgo.Newf("duplicate id %q in meeting store", id)
+	}
 	s.data[id] = meetingStoreEntry{
 		address: address,
 		time:    now,

--- a/store/testing/meeting.go
+++ b/store/testing/meeting.go
@@ -130,6 +130,16 @@ func (s *MeetingSuite) TestRemoveOld(c *gc.C) {
 	}
 }
 
+func (s *MeetingSuite) TestPutSameIDTwice(c *gc.C) {
+	err := s.Store.Put(s.ctx, "x", "addr1")
+	c.Assert(err, gc.Equals, nil)
+	// Putting the same id should result in an error.
+	err = s.Store.Put(s.ctx, "x", "addr2")
+	if err == nil {
+		c.Errorf("expected error from putting same id twice; got no error")
+	}
+}
+
 func (s *MeetingSuite) TestContext(c *gc.C) {
 	ctx, close := s.Store.Context(s.ctx)
 	defer close()


### PR DESCRIPTION
Previously, if two clients attempted to discharge
a macaroon with the same third party caveat id at the
same time, one of the attempts would fail because
discharge ids were deterministically determined from
the caveat id.

Since we no longer tie discharge tokens to a particular
discharge, we no longer need to know the discharge id
in advance, so we remove the for-discharge caveat and
make the discharge id random for every new discharge
request.