### PR TITLE
add a candid generate-keys command to create a keypair

### DIFF
--- a/cmd/candid/internal/admincmd/command.go
+++ b/cmd/candid/internal/admincmd/command.go
@@ -59,6 +59,7 @@ func New() cmd.Command {
 	supercmd.Register(newFindCommand(c))
 	supercmd.Register(newRemoveGroupCommand(c))
 	supercmd.Register(newShowCommand(c))
+	supercmd.Register(newGenerateKeysCommand(c))
 	return supercmd
 }
 

--- a/cmd/candid/internal/admincmd/generate-keys.go
+++ b/cmd/candid/internal/admincmd/generate-keys.go
@@ -1,0 +1,56 @@
+// Copyright 2018 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package admincmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/juju/cmd"
+	"gopkg.in/errgo.v1"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+)
+
+type generateKeysCommand struct {
+	*candidCommand
+}
+
+func newGenerateKeysCommand(cc *candidCommand) cmd.Command {
+	c := &generateKeysCommand{}
+	c.candidCommand = cc
+	return c
+}
+
+var generateKeysDoc = `
+The generate-keys command generates a public/private that can be used in
+candid configuration.
+`
+
+func (c *generateKeysCommand) Info() *cmd.Info {
+	return &cmd.Info{
+		Name:    "generate-keys",
+		Purpose: "generate a public/private keypair",
+		Doc:     generateKeysDoc,
+	}
+}
+
+func (c *generateKeysCommand) Init(args []string) error {
+	return errgo.Mask(c.candidCommand.Init(nil))
+}
+
+func (c *generateKeysCommand) Run(ctxt *cmd.Context) error {
+	defer c.Close(ctxt)
+
+	keyPair, err := bakery.GenerateKey()
+	if err != nil {
+		return errgo.Mask(err)
+	}
+
+	text, err := json.MarshalIndent(keyPair, "", "\t")
+	if err != nil {
+		return errgo.Mask(err)
+	}
+	fmt.Fprintf(ctxt.Stdout, "%s\n", text)
+	return nil
+}

--- a/cmd/candid/internal/admincmd/generate-keys.go
+++ b/cmd/candid/internal/admincmd/generate-keys.go
@@ -23,8 +23,8 @@ func newGenerateKeysCommand(cc *candidCommand) cmd.Command {
 }
 
 var generateKeysDoc = `
-The generate-keys command generates a public/private that can be used in
-candid configuration.
+The generate-keys command generates a public/private keypair that can be used
+in candid configuration.
 `
 
 func (c *generateKeysCommand) Info() *cmd.Info {

--- a/cmd/candid/internal/admincmd/generate-keys_test.go
+++ b/cmd/candid/internal/admincmd/generate-keys_test.go
@@ -1,0 +1,25 @@
+// Copyright 2016 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package admincmd_test
+
+import (
+	"encoding/json"
+
+	gc "gopkg.in/check.v1"
+)
+
+type generateKeysSuite struct {
+	commandSuite
+}
+
+var _ = gc.Suite(&generateKeysSuite{})
+
+func (s *generateKeysSuite) TestAddGroup(c *gc.C) {
+	stdout := CheckSuccess(c, s.Run, "generate-keys")
+	var data interface{}
+	err := json.Unmarshal([]byte(stdout), &data)
+	c.Assert(err, gc.IsNil)
+	c.Assert(data.(map[string]interface{})["private"], gc.Not(gc.Equals), "")
+	c.Assert(data.(map[string]interface{})["public"], gc.Not(gc.Equals), "")
+}


### PR DESCRIPTION
Add a `candid generate-keys` command to create a keypair for use in the config file.

It works exactly like `bakery-keygen`.