### PR TITLE
store: add Update method

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -52,7 +52,7 @@ gopkg.in/macaroon-bakery.v2	git	a0743b6619d68bbf8dc5cabbb49738b846f06080	2018-04
 gopkg.in/macaroon.v2	git	bed2a428da6e56d950bed5b41fcbae3141e5b0d0	2017-10-17T15:30:37Z
 gopkg.in/mgo.v2	git	3f83fa5005286a7fe593b055f0d7771a7dce4655	2016-08-18T02:01:20Z
 gopkg.in/natefinch/lumberjack.v2	git	df99d62fd42d8b3752c8a42c6723555372c02a03	2017-05-31T18:08:50Z
-gopkg.in/retry.v1	git	01631078ef2fdce601e38cfe5f527fab24c9a6d2	2017-05-31T09:12:38Z
+gopkg.in/retry.v1	git	2d7c7c65cc71d024968d9ff4385d5e7ad3a83fcc	2018-01-16T15:34:15Z
 gopkg.in/square/go-jose.v2	git	296c7f1463ec9b712176dc804dea0173d06dc728	2016-11-17T00:42:38Z
 gopkg.in/tomb.v2	git	14b3d72120e8d10ea6e6b7f87f7175734b1faab8	2014-06-26T14:46:23Z
 gopkg.in/yaml.v2	git	1244d3ce02e3e1c16820ada0bae506b6c479f106	2018-01-08T13:15:54Z

--- a/idp/usso/internal/kvnoncestore/store.go
+++ b/idp/usso/internal/kvnoncestore/store.go
@@ -69,7 +69,7 @@ func (s *Store) accept(endpoint, nonce string, now time.Time) error {
 		return errgo.Newf("%q too old", nonce)
 	}
 	key := fmt.Sprintf("nonce#%s#%s", endpoint, nonce)
-	err = s.store.Add(context.Background(), key, nil, t.Add(s.maxAge))
+	err = store.SetKeyOnce(context.Background(), s.store, key, nil, t.Add(s.maxAge))
 	if errgo.Cause(err) == store.ErrDuplicateKey {
 		return errgo.Newf("%q already seen for %q", nonce, endpoint)
 	}

--- a/store/mgostore/keyvalue.go
+++ b/store/mgostore/keyvalue.go
@@ -4,56 +4,58 @@
 package mgostore
 
 import (
+	"bytes"
 	"time"
 
 	"golang.org/x/net/context"
 	errgo "gopkg.in/errgo.v1"
 	mgo "gopkg.in/mgo.v2"
+	"gopkg.in/mgo.v2/bson"
+	retry "gopkg.in/retry.v1"
 
 	"github.com/CanonicalLtd/candid/store"
 )
 
 // an providerDataStore implements store.ProviderDataStore.
 type providerDataStore struct {
-	b *backend
+	backend *backend
 }
 
 func (s *providerDataStore) KeyValueStore(ctx context.Context, idp string) (store.KeyValueStore, error) {
-	collection := "kv-idp-" + idp
-	coll := s.b.c(ctx, collection)
+	collection := "kv" + idp
+	coll := s.backend.c(ctx, collection)
 	defer coll.Database.Session.Close()
 
 	if err := coll.EnsureIndex(mgo.Index{Key: []string{"expire"}, ExpireAfter: time.Nanosecond}); err != nil {
 		return nil, errgo.Mask(err)
 	}
-
 	return &keyValueStore{
-		b:          s.b,
+		backend:    s.backend,
 		collection: collection,
 	}, nil
 }
 
 // a keyValueStore implements store.KeyValueStore.
 type keyValueStore struct {
-	b          *backend
+	backend    *backend
 	collection string
 }
 
 // Context implements idp.KeyValueStore.Context.
 func (s *keyValueStore) Context(ctx context.Context) (context.Context, func()) {
-	return s.b.context(ctx)
+	return s.backend.context(ctx)
 }
 
 type kvDoc struct {
-	Key    string    `bson:"_id,omitempty"`
-	Value  []byte    `bson:",omitempty"`
+	Key    string    `bson:"_id"`
+	Value  []byte    `bson:"value'`
 	Expire time.Time `bson:",omitempty"`
 }
 
 // Get implements store.KeyValueStore.Get by retrieving the document with
 // the given key from the store's collection.
 func (s *keyValueStore) Get(ctx context.Context, key string) ([]byte, error) {
-	coll := s.b.c(ctx, s.collection)
+	coll := s.backend.c(ctx, s.collection)
 	defer coll.Database.Session.Close()
 
 	var doc kvDoc
@@ -69,34 +71,81 @@ func (s *keyValueStore) Get(ctx context.Context, key string) ([]byte, error) {
 // Set implements store.KeyValueStore.Set by upserting the document with
 // the given key, value and expire time into the store's collection.
 func (s *keyValueStore) Set(ctx context.Context, key string, value []byte, expire time.Time) error {
-	coll := s.b.c(ctx, s.collection)
+	coll := s.backend.c(ctx, s.collection)
 	defer coll.Database.Session.Close()
 
-	_, err := coll.UpsertId(key, kvDoc{
-		Key:    key,
-		Value:  value,
-		Expire: expire,
-	})
+	_, err := coll.UpsertId(key, bson.D{{
+		"$set", bson.D{{
+			"value", value,
+		}, {
+			"expire", expire,
+		}},
+	}})
 	return errgo.Mask(err)
 }
 
-// Add implements store.KeyValueStore.Add by inserting a document with
-// the given key, value and expire time into the store's collection.
-func (s *keyValueStore) Add(ctx context.Context, key string, value []byte, expire time.Time) error {
-	coll := s.b.c(ctx, s.collection)
+var updateStrategy = retry.Exponential{
+	Initial:  time.Microsecond,
+	Factor:   2,
+	MaxDelay: 500 * time.Millisecond,
+	Jitter:   true,
+}
+
+func (s *keyValueStore) Update(ctx context.Context, key string, expire time.Time, getVal func(old []byte) ([]byte, error)) error {
+	coll := s.backend.c(ctx, s.collection)
 	defer coll.Database.Session.Close()
 
-	doc := kvDoc{
-		Key:    key,
-		Value:  value,
-		Expire: expire,
-	}
-
-	if err := coll.Insert(doc); err != nil {
-		if mgo.IsDup(err) {
-			return store.DuplicateKeyError(key)
+	for r := retry.Start(updateStrategy, nil); r.Next(); {
+		var doc kvDoc
+		if err := coll.Find(bson.D{{"_id", key}}).One(&doc); err != nil {
+			if errgo.Cause(err) != mgo.ErrNotFound {
+				return errgo.Mask(err)
+			}
+			newVal, err := getVal(nil)
+			if err != nil {
+				return errgo.Mask(err, errgo.Any)
+			}
+			err = coll.Insert(kvDoc{
+				Key:    key,
+				Value:  newVal,
+				Expire: expire,
+			})
+			if err == nil {
+				return nil
+			}
+			if !mgo.IsDup(err) {
+				return errgo.Mask(err)
+			}
+			// A new document has been inserted after we did the FindId and before Insert,
+			// so try again.
+			continue
 		}
-		return errgo.Mask(err)
+		newVal, err := getVal(doc.Value)
+		if err != nil {
+			return errgo.Mask(err, errgo.Any)
+		}
+		if bytes.Equal(newVal, doc.Value) {
+			return nil
+		}
+		err = coll.Update(bson.D{{
+			"_id", key,
+		}, {
+			"value", doc.Value,
+		}}, bson.D{{
+			"$set", bson.D{{
+				"value", newVal,
+			}, {
+				"expire", expire,
+			}},
+		}})
+		if err == nil {
+			return nil
+		}
+		if err != mgo.ErrNotFound {
+			return errgo.Mask(err)
+		}
+		// The document has been removed or updated since we retrieved it,
+		// so try again.
 	}
-	return nil
+	return errgo.Newf("too many retry attempts trying to update key")
 }

--- a/store/sqlstore/backend.go
+++ b/store/sqlstore/backend.go
@@ -110,6 +110,7 @@ const (
 	tmplPushIdentitySet
 	tmplPullIdentitySet
 	tmplGetProviderData
+	tmplGetProviderDataForUpdate
 	tmplInsertProviderData
 	tmplGetMeeting
 	tmplPutMeeting

--- a/store/sqlstore/postgres.go
+++ b/store/sqlstore/postgres.go
@@ -118,6 +118,10 @@ var postgresTmpls = [numTmpl]string{
 	tmplGetProviderData: `
 		SELECT value FROM provider_data
 		WHERE provider={{.Provider | .Arg}} AND key={{.Key | .Arg}} AND (expire IS NULL OR expire > now())`,
+	tmplGetProviderDataForUpdate: `
+		SELECT value FROM provider_data
+		WHERE provider={{.Provider | .Arg}} AND key={{.Key | .Arg}} AND (expire IS NULL OR expire > now())
+		FOR UPDATE`,
 	tmplInsertProviderData: `
 		INSERT INTO provider_data (provider, key, value, expire)
 		VALUES ({{.Provider | .Arg}}, {{.Key | .Arg}}, {{.Value | .Arg}}, {{.Expire | .Arg}})


### PR DESCRIPTION
This is more general than Add, and can be used as a basis for
other key-value related storage, such as global ACLs and
general settings.
