### PR TITLE
qtcandidtest: new test fixtures

### DIFF
--- a/cmd/candid/internal/admincmd/add-group_test.go
+++ b/cmd/candid/internal/admincmd/add-group_test.go
@@ -4,10 +4,11 @@
 package admincmd_test
 
 import (
-	"github.com/CanonicalLtd/candid/store"
 	jc "github.com/juju/testing/checkers"
 	"golang.org/x/net/context"
 	gc "gopkg.in/check.v1"
+
+	"github.com/CanonicalLtd/candid/store"
 )
 
 type addGroupSuite struct {

--- a/cmd/candid/internal/admincmd/find_test.go
+++ b/cmd/candid/internal/admincmd/find_test.go
@@ -7,10 +7,11 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/CanonicalLtd/candid/store"
 	jc "github.com/juju/testing/checkers"
 	"golang.org/x/net/context"
 	gc "gopkg.in/check.v1"
+
+	"github.com/CanonicalLtd/candid/store"
 )
 
 type findSuite struct {

--- a/cmd/candid/internal/admincmd/remove-group_test.go
+++ b/cmd/candid/internal/admincmd/remove-group_test.go
@@ -4,10 +4,11 @@
 package admincmd_test
 
 import (
-	"github.com/CanonicalLtd/candid/store"
 	jc "github.com/juju/testing/checkers"
 	"golang.org/x/net/context"
 	gc "gopkg.in/check.v1"
+
+	"github.com/CanonicalLtd/candid/store"
 )
 
 type removeGroupSuite struct {

--- a/cmd/candid/internal/admincmd/show_test.go
+++ b/cmd/candid/internal/admincmd/show_test.go
@@ -7,10 +7,11 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/CanonicalLtd/candid/store"
 	"golang.org/x/net/context"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon-bakery.v2/bakery"
+
+	"github.com/CanonicalLtd/candid/store"
 )
 
 type showSuite struct {

--- a/cmd/candidsrv/main.go
+++ b/cmd/candidsrv/main.go
@@ -28,13 +28,12 @@ import (
 	_ "github.com/CanonicalLtd/candid/idp/keystone"
 	_ "github.com/CanonicalLtd/candid/idp/ldap"
 	_ "github.com/CanonicalLtd/candid/idp/static"
-	_ "github.com/CanonicalLtd/candid/store/memstore"
-	_ "github.com/CanonicalLtd/candid/store/mgostore"
-	_ "github.com/CanonicalLtd/candid/store/sqlstore"
-
 	"github.com/CanonicalLtd/candid/idp/usso"
 	_ "github.com/CanonicalLtd/candid/idp/usso/ussodischarge"
 	_ "github.com/CanonicalLtd/candid/idp/usso/ussooauth"
+	_ "github.com/CanonicalLtd/candid/store/memstore"
+	_ "github.com/CanonicalLtd/candid/store/mgostore"
+	_ "github.com/CanonicalLtd/candid/store/sqlstore"
 )
 
 var logger = loggo.GetLogger("candidsrv")

--- a/idp/idp.go
+++ b/idp/idp.go
@@ -8,12 +8,12 @@ import (
 	"html/template"
 	"net/http"
 
+	"github.com/juju/simplekv"
 	"golang.org/x/net/context"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon-bakery.v2/httpbakery"
 
 	"github.com/CanonicalLtd/candid/store"
-	"github.com/juju/simplekv"
 )
 
 // A DischargeTokenCreator is used by the identity providers to create a

--- a/idp/keystone/discharge_test.go
+++ b/idp/keystone/discharge_test.go
@@ -10,6 +10,8 @@ import (
 	"regexp"
 	"testing"
 
+	qt "github.com/frankban/quicktest"
+	"github.com/frankban/quicktest/qtsuite"
 	"golang.org/x/net/context"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/httprequest.v1"
@@ -23,8 +25,6 @@ import (
 	"github.com/CanonicalLtd/candid/internal/discharger"
 	"github.com/CanonicalLtd/candid/internal/identity"
 	candidtest "github.com/CanonicalLtd/candid/internal/qtcandidtest"
-	qt "github.com/frankban/quicktest"
-	"github.com/frankban/quicktest/qtsuite"
 )
 
 type dischargeSuite struct {

--- a/internal/candidtest/server.go
+++ b/internal/candidtest/server.go
@@ -10,6 +10,8 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/juju/aclstore/v2"
+	"github.com/juju/simplekv/memsimplekv"
 	"golang.org/x/net/context"
 	"gopkg.in/CanonicalLtd/candidclient.v1"
 	gc "gopkg.in/check.v1"
@@ -21,8 +23,6 @@ import (
 	"github.com/CanonicalLtd/candid/internal/auth"
 	"github.com/CanonicalLtd/candid/internal/identity"
 	"github.com/CanonicalLtd/candid/store"
-	"github.com/juju/aclstore/v2"
-	"github.com/juju/simplekv/memsimplekv"
 )
 
 var DefaultTemplate = template.New("")

--- a/internal/discharger/export_test.go
+++ b/internal/discharger/export_test.go
@@ -4,10 +4,11 @@
 package discharger
 
 import (
+	"github.com/juju/simplekv"
+
 	"github.com/CanonicalLtd/candid/idp"
 	"github.com/CanonicalLtd/candid/internal/discharger/internal"
 	"github.com/CanonicalLtd/candid/internal/identity"
-	"github.com/juju/simplekv"
 )
 
 var NewIDPHandler = newIDPHandler

--- a/internal/discharger/internal/store.go
+++ b/internal/discharger/internal/store.go
@@ -9,12 +9,12 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/juju/simplekv"
 	"golang.org/x/net/context"
 	errgo "gopkg.in/errgo.v1"
 	"gopkg.in/macaroon-bakery.v2/httpbakery"
 
 	"github.com/CanonicalLtd/candid/store"
-	"github.com/juju/simplekv"
 )
 
 // DischargeTokenStore is a store for discharge tokens. It wraps a

--- a/internal/discharger/internal/store_test.go
+++ b/internal/discharger/internal/store_test.go
@@ -4,9 +4,8 @@
 package internal_test
 
 import (
-	"time"
-
 	"context"
+	"time"
 
 	"github.com/juju/simplekv"
 	jc "github.com/juju/testing/checkers"

--- a/internal/qtcandidtest/discharge.go
+++ b/internal/qtcandidtest/discharge.go
@@ -97,7 +97,7 @@ func (s *DischargeCreator) AssertMacaroon(c *qt.C, ms macaroon.Slice, op bakery.
 // A VisitorFunc converts a function to a httpbakery.LegacyInteractor.
 type VisitorFunc func(*url.URL) error
 
-// VisitWebPage implements httpbakery.Visitor.VisitWebPage.
+// LegacyInteract implements httpbakery.LegacyInteractor.LegacyInteract.
 func (f VisitorFunc) LegacyInteract(ctx context.Context, _ *httpbakery.Client, _ string, u *url.URL) error {
 	return f(u)
 }

--- a/internal/qtcandidtest/discharge.go
+++ b/internal/qtcandidtest/discharge.go
@@ -9,52 +9,52 @@ import (
 	"net/url"
 	"time"
 
+	qt "github.com/frankban/quicktest"
 	"golang.org/x/net/context"
-	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
 	"gopkg.in/macaroon-bakery.v2/bakery/identchecker"
 	"gopkg.in/macaroon-bakery.v2/httpbakery"
 	macaroon "gopkg.in/macaroon.v2"
-
-	"github.com/CanonicalLtd/candid/internal/discharger"
-	"github.com/CanonicalLtd/candid/internal/identity"
 )
 
-// A DischargeSuite is a test suite useful for testing discharges.
-type DischargeSuite struct {
-	StoreServerSuite
+// DischargeCreator represents a third party service
+// that creates discharges addressed to Candid.
+type DischargeCreator struct {
+	ServerURL string
 
 	Bakery *identchecker.Bakery
 
 	bakeryKey *bakery.KeyPair
 }
 
-// SetUpTest creates a new identity server ready to perform discharges
-// and serves it.
-func (s *DischargeSuite) SetUpTest(c *gc.C) {
-	s.Versions = map[string]identity.NewAPIHandlerFunc{
-		"discharger": discharger.NewAPIHandler,
+// NewDischargeCreator returns a DischargeCreator that
+// creates third party caveats addressed to the given server,
+// which must be serving the "discharger" API.
+func NewDischargeCreator(server *Server) *DischargeCreator {
+	bakeryKey, err := bakery.GenerateKey()
+	if err != nil {
+		panic(err)
 	}
-	s.StoreServerSuite.SetUpTest(c)
-	var err error
-	s.bakeryKey, err = bakery.GenerateKey()
-	c.Assert(err, gc.Equals, nil)
-	s.Bakery = identchecker.NewBakery(identchecker.BakeryParams{
-		Locator:        s,
-		Key:            s.bakeryKey,
-		IdentityClient: s.AdminIdentityClient(c),
-		Location:       "discharge-test",
-	})
+	return &DischargeCreator{
+		ServerURL: server.URL,
+		Bakery: identchecker.NewBakery(identchecker.BakeryParams{
+			Locator:        server,
+			Key:            bakeryKey,
+			IdentityClient: server.AdminIdentityClient(),
+			Location:       "discharge-test",
+		}),
+		bakeryKey: bakeryKey,
+	}
 }
 
 // AssertDischarge checks that a macaroon can be discharged with
 // interaction using the specified visitor.
-func (s *DischargeSuite) AssertDischarge(c *gc.C, i httpbakery.Interactor) {
-	ms, err := s.Discharge(c, "is-authenticated-user", s.Client(i))
-	c.Assert(err, gc.Equals, nil)
+func (s *DischargeCreator) AssertDischarge(c *qt.C, i httpbakery.Interactor) {
+	ms, err := s.Discharge(c, "is-authenticated-user", BakeryClient(i))
+	c.Assert(err, qt.Equals, nil)
 	_, err = s.Bakery.Checker.Auth(ms).Allow(context.Background(), identchecker.LoginOp)
-	c.Assert(err, gc.Equals, nil)
+	c.Assert(err, qt.Equals, nil)
 }
 
 // Discharge attempts to perform a discharge of a new macaroon against
@@ -62,36 +62,36 @@ func (s *DischargeSuite) AssertDischarge(c *gc.C, i httpbakery.Interactor) {
 // macaroon slice containing a discharged macaroon or any error. The
 // newly minted macaroon will have a third-party caveat addressed to the
 // identity server with the given condition.
-func (s *DischargeSuite) Discharge(c *gc.C, condition string, client *httpbakery.Client) (macaroon.Slice, error) {
-	return client.DischargeAll(s.Ctx, s.NewMacaroon(c, condition, identchecker.LoginOp))
+func (s *DischargeCreator) Discharge(c *qt.C, condition string, client *httpbakery.Client) (macaroon.Slice, error) {
+	return client.DischargeAll(context.Background(), s.NewMacaroon(c, condition, identchecker.LoginOp))
 }
 
 // NewMacaroon creates a new macaroon with a third-party caveat addressed
 // to the identity server which has the given condition.
-func (s *DischargeSuite) NewMacaroon(c *gc.C, condition string, op bakery.Op) *bakery.Macaroon {
+func (s *DischargeCreator) NewMacaroon(c *qt.C, condition string, op bakery.Op) *bakery.Macaroon {
 	m, err := s.Bakery.Oven.NewMacaroon(
 		context.Background(),
 		bakery.LatestVersion,
 		[]checkers.Caveat{{
-			Location:  s.URL,
+			Location:  s.ServerURL,
 			Condition: condition,
 		}, checkers.TimeBeforeCaveat(time.Now().Add(time.Minute))},
 		op,
 	)
-	c.Assert(err, gc.Equals, nil)
+	c.Assert(err, qt.Equals, nil)
 	return m
 }
 
 // AssertMacaroon asserts that the given macaroon slice is valid for the
 // given operation. If id is specified then the declared identity in the
 // macaroon is checked to be the same as id.
-func (s *DischargeSuite) AssertMacaroon(c *gc.C, ms macaroon.Slice, op bakery.Op, id string) {
+func (s *DischargeCreator) AssertMacaroon(c *qt.C, ms macaroon.Slice, op bakery.Op, id string) {
 	ui, err := s.Bakery.Checker.Auth(ms).Allow(context.Background(), op)
-	c.Assert(err, gc.Equals, nil)
+	c.Assert(err, qt.Equals, nil)
 	if id == "" {
 		return
 	}
-	c.Assert(ui.Identity.Id(), gc.Equals, id)
+	c.Assert(ui.Identity.Id(), qt.Equals, id)
 }
 
 // A VisitorFunc converts a function to a httpbakery.LegacyInteractor.

--- a/internal/qtcandidtest/discharge.go
+++ b/internal/qtcandidtest/discharge.go
@@ -1,0 +1,103 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+// Package candidtest provides suites and functions useful for testing the
+// identity manager.
+package candidtest
+
+import (
+	"net/url"
+	"time"
+
+	"golang.org/x/net/context"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+	"gopkg.in/macaroon-bakery.v2/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2/bakery/identchecker"
+	"gopkg.in/macaroon-bakery.v2/httpbakery"
+	macaroon "gopkg.in/macaroon.v2"
+
+	"github.com/CanonicalLtd/candid/internal/discharger"
+	"github.com/CanonicalLtd/candid/internal/identity"
+)
+
+// A DischargeSuite is a test suite useful for testing discharges.
+type DischargeSuite struct {
+	StoreServerSuite
+
+	Bakery *identchecker.Bakery
+
+	bakeryKey *bakery.KeyPair
+}
+
+// SetUpTest creates a new identity server ready to perform discharges
+// and serves it.
+func (s *DischargeSuite) SetUpTest(c *gc.C) {
+	s.Versions = map[string]identity.NewAPIHandlerFunc{
+		"discharger": discharger.NewAPIHandler,
+	}
+	s.StoreServerSuite.SetUpTest(c)
+	var err error
+	s.bakeryKey, err = bakery.GenerateKey()
+	c.Assert(err, gc.Equals, nil)
+	s.Bakery = identchecker.NewBakery(identchecker.BakeryParams{
+		Locator:        s,
+		Key:            s.bakeryKey,
+		IdentityClient: s.AdminIdentityClient(c),
+		Location:       "discharge-test",
+	})
+}
+
+// AssertDischarge checks that a macaroon can be discharged with
+// interaction using the specified visitor.
+func (s *DischargeSuite) AssertDischarge(c *gc.C, i httpbakery.Interactor) {
+	ms, err := s.Discharge(c, "is-authenticated-user", s.Client(i))
+	c.Assert(err, gc.Equals, nil)
+	_, err = s.Bakery.Checker.Auth(ms).Allow(context.Background(), identchecker.LoginOp)
+	c.Assert(err, gc.Equals, nil)
+}
+
+// Discharge attempts to perform a discharge of a new macaroon against
+// this suites identity server using the given client and returns a
+// macaroon slice containing a discharged macaroon or any error. The
+// newly minted macaroon will have a third-party caveat addressed to the
+// identity server with the given condition.
+func (s *DischargeSuite) Discharge(c *gc.C, condition string, client *httpbakery.Client) (macaroon.Slice, error) {
+	return client.DischargeAll(s.Ctx, s.NewMacaroon(c, condition, identchecker.LoginOp))
+}
+
+// NewMacaroon creates a new macaroon with a third-party caveat addressed
+// to the identity server which has the given condition.
+func (s *DischargeSuite) NewMacaroon(c *gc.C, condition string, op bakery.Op) *bakery.Macaroon {
+	m, err := s.Bakery.Oven.NewMacaroon(
+		context.Background(),
+		bakery.LatestVersion,
+		[]checkers.Caveat{{
+			Location:  s.URL,
+			Condition: condition,
+		}, checkers.TimeBeforeCaveat(time.Now().Add(time.Minute))},
+		op,
+	)
+	c.Assert(err, gc.Equals, nil)
+	return m
+}
+
+// AssertMacaroon asserts that the given macaroon slice is valid for the
+// given operation. If id is specified then the declared identity in the
+// macaroon is checked to be the same as id.
+func (s *DischargeSuite) AssertMacaroon(c *gc.C, ms macaroon.Slice, op bakery.Op, id string) {
+	ui, err := s.Bakery.Checker.Auth(ms).Allow(context.Background(), op)
+	c.Assert(err, gc.Equals, nil)
+	if id == "" {
+		return
+	}
+	c.Assert(ui.Identity.Id(), gc.Equals, id)
+}
+
+// A VisitorFunc converts a function to a httpbakery.LegacyInteractor.
+type VisitorFunc func(*url.URL) error
+
+// VisitWebPage implements httpbakery.Visitor.VisitWebPage.
+func (f VisitorFunc) LegacyInteract(ctx context.Context, _ *httpbakery.Client, _ string, u *url.URL) error {
+	return f(u)
+}

--- a/internal/qtcandidtest/logging.go
+++ b/internal/qtcandidtest/logging.go
@@ -1,0 +1,43 @@
+package candidtest
+
+import (
+	"os"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/juju/loggo"
+)
+
+// LogTo configures loggo to log to qt.C for the duration
+// of the test. If TEST_LOGGING_CONFIG is set, it
+// will be used to configure the logging modules/.
+//
+// When c.Done is called, the loggo configuration will
+// be reset.
+func LogTo(c *qt.C) {
+	cfg := os.Getenv("TEST_LOGGING_CONFIG")
+	if cfg == "" {
+		cfg = "DEBUG"
+	}
+	// Don't use the default writer for the test logging, which
+	// means we can still get logging output from tests that
+	// replace the default writer.
+	loggo.ResetLogging()
+	loggo.RegisterWriter(loggo.DefaultWriterName, discardWriter{})
+	loggo.RegisterWriter("testlogger", &loggoWriter{c})
+	err := loggo.ConfigureLoggers(cfg)
+	c.Assert(err, qt.Equals, nil)
+	c.Defer(loggo.ResetLogging)
+}
+
+type loggoWriter struct {
+	c *qt.C
+}
+
+func (w *loggoWriter) Write(entry loggo.Entry) {
+	w.c.Logf("%s %s %s", entry.Level, entry.Module, entry.Message)
+}
+
+type discardWriter struct{}
+
+func (discardWriter) Write(entry loggo.Entry) {
+}

--- a/internal/qtcandidtest/logging.go
+++ b/internal/qtcandidtest/logging.go
@@ -9,7 +9,7 @@ import (
 
 // LogTo configures loggo to log to qt.C for the duration
 // of the test. If TEST_LOGGING_CONFIG is set, it
-// will be used to configure the logging modules/.
+// will be used to configure the logging modules.
 //
 // When c.Done is called, the loggo configuration will
 // be reset.

--- a/internal/qtcandidtest/server.go
+++ b/internal/qtcandidtest/server.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 
 	qt "github.com/frankban/quicktest"
+	aclstore "github.com/juju/aclstore/v2"
+	"github.com/juju/simplekv/memsimplekv"
 	"golang.org/x/net/context"
 	"gopkg.in/CanonicalLtd/candidclient.v1"
 	errgo "gopkg.in/errgo.v1"
@@ -21,8 +23,6 @@ import (
 	"github.com/CanonicalLtd/candid/internal/auth"
 	"github.com/CanonicalLtd/candid/internal/identity"
 	"github.com/CanonicalLtd/candid/store"
-	aclstore "github.com/juju/aclstore/v2"
-	"github.com/juju/simplekv/memsimplekv"
 )
 
 var DefaultTemplate = template.New("")
@@ -110,8 +110,8 @@ func NewServer(c *qt.C, p identity.ServerParams, versions map[string]identity.Ne
 	return s
 }
 
-// ThirdPartyInfo implements bakery.ThirdPartyLocator.THirdPartyInfo
-// allowing the suite to be used as a bakery.ThirdPArtyLocator.
+// ThirdPartyInfo implements bakery.ThirdPartyLocator.ThirdPartyInfo
+// allowing the suite to be used as a bakery.ThirdPartyLocator.
 func (s *Server) ThirdPartyInfo(ctx context.Context, loc string) (bakery.ThirdPartyInfo, error) {
 	if loc != s.URL {
 		return bakery.ThirdPartyInfo{}, bakery.ErrNotFound

--- a/internal/qtcandidtest/server.go
+++ b/internal/qtcandidtest/server.go
@@ -1,0 +1,289 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package candidtest
+
+import (
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+
+	"golang.org/x/net/context"
+	"gopkg.in/CanonicalLtd/candidclient.v1"
+	gc "gopkg.in/check.v1"
+	errgo "gopkg.in/errgo.v1"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+	"gopkg.in/macaroon-bakery.v2/httpbakery"
+	"gopkg.in/macaroon-bakery.v2/httpbakery/agent"
+
+	"github.com/CanonicalLtd/candid/internal/auth"
+	"github.com/CanonicalLtd/candid/internal/identity"
+	"github.com/CanonicalLtd/candid/store"
+	"github.com/juju/aclstore/v2"
+	"github.com/juju/simplekv/memsimplekv"
+)
+
+var DefaultTemplate = template.New("")
+
+func init() {
+	template.Must(DefaultTemplate.New("login").Parse(loginTemplate))
+}
+
+const loginTemplate = "login successful as user {{.Username}}\n"
+
+// A ServerSuite is a test suite that
+type ServerSuite struct {
+	// Params is used to configure the server. Any settings must be
+	// set before calling SetUpTest. At the least Store, MeetingStore
+	// and RootKeyStore must be configured.
+	Params identity.ServerParams
+
+	// Versions configures the API versions which will be served by
+	// the server. This must be set before calling SetUpTest.
+	Versions map[string]identity.NewAPIHandlerFunc
+
+	// The following fields will be available after calling SetUpTest.
+
+	// URL contains the URL of the server.
+	URL string
+
+	// Ctx contains a context.Context that has been initialised with
+	// the servers.
+	Ctx context.Context
+
+	// params contains the final parameters that were passed to
+	// identity.New.
+	params            identity.ServerParams
+	handler           *identity.Server
+	server            *httptest.Server
+	adminAgentKey     *bakery.KeyPair
+	closeStore        func()
+	closeMeetingStore func()
+	agentID           int
+}
+
+// SetUpTest creates a new identity server and serves it. The server is
+// configured based on the Params and Versions fields. If the Key
+// parameter is not set then a new key will be generated. If the
+// PrivateAddr parameter is not set then it will default to localhost. If
+// the adminAgentPublicKey is not set then a new key will be generated,
+// note that if it is set the AdminClient and AdminIdentityClient can not
+// be used. If the Template parameter is not set then DefaultTemplate
+// will be used.
+func (s *ServerSuite) SetUpTest(c *gc.C) {
+	s.params = s.Params
+	if s.params.ACLStore == nil {
+		s.params.ACLStore = aclstore.NewACLStore(memsimplekv.NewStore())
+	}
+	s.server = httptest.NewUnstartedServer(nil)
+	s.params.Location = "http://" + s.server.Listener.Addr().String()
+	if s.params.Key == nil {
+		var err error
+		s.params.Key, err = bakery.GenerateKey()
+		c.Assert(err, gc.Equals, nil)
+	}
+	if s.params.PrivateAddr == "" {
+		s.params.PrivateAddr = "localhost"
+	}
+	if s.params.AdminAgentPublicKey == nil {
+		var err error
+		s.adminAgentKey, err = bakery.GenerateKey()
+		c.Assert(err, gc.Equals, nil)
+		s.params.AdminAgentPublicKey = &s.adminAgentKey.Public
+	}
+	if s.params.Template == nil {
+		s.params.Template = DefaultTemplate
+	}
+	var err error
+	s.handler, err = identity.New(s.params, s.Versions)
+	c.Assert(err, gc.Equals, nil)
+
+	s.server.Config.Handler = s.handler
+	s.server.Start()
+	s.URL = s.server.URL
+	s.Ctx, s.closeStore = s.Params.Store.Context(context.Background())
+	s.Ctx, s.closeMeetingStore = s.Params.MeetingStore.Context(context.Background())
+}
+
+// TearDownTest cleans up the resources created during SetUpTest.
+func (s *ServerSuite) TearDownTest(c *gc.C) {
+	s.closeMeetingStore()
+	s.closeStore()
+	s.server.Close()
+	s.handler.Close()
+}
+
+// ThirdPartyInfo implements bakery.ThirdPartyLocator.THirdPartyInfo
+// allowing the suite to be used as a bakery.ThirdPArtyLocator.
+func (s *ServerSuite) ThirdPartyInfo(ctx context.Context, loc string) (bakery.ThirdPartyInfo, error) {
+	if loc != s.URL {
+		return bakery.ThirdPartyInfo{}, bakery.ErrNotFound
+	}
+	return bakery.ThirdPartyInfo{
+		PublicKey: s.params.Key.Public,
+		Version:   bakery.LatestVersion,
+	}, nil
+}
+
+// Client creates a new httpbakery.Client which uses the given visitor as
+// its WebPageVisitor. If no Visitor is specified then NoVisit will be
+// used.
+func (s *ServerSuite) Client(i httpbakery.Interactor) *httpbakery.Client {
+	cl := &httpbakery.Client{
+		Client: httpbakery.NewHTTPClient(),
+	}
+	if i != nil {
+		cl.AddInteractor(i)
+	}
+	return cl
+}
+
+// AdminClient creates a new httpbakery.Client that is configured to log
+// in as an admin user.
+func (s *ServerSuite) AdminClient() *httpbakery.Client {
+	client := &httpbakery.Client{
+		Client: httpbakery.NewHTTPClient(),
+		Key:    s.adminAgentKey,
+	}
+	agent.SetUpAuth(client, &agent.AuthInfo{
+		Key: s.adminAgentKey,
+		Agents: []agent.Agent{{
+			URL:      s.URL,
+			Username: auth.AdminUsername,
+		}},
+	})
+	return client
+}
+
+// AdminIdentityClient creates a new candidclient.Client that is configured to log
+// in as an admin user.
+func (s *ServerSuite) AdminIdentityClient(c *gc.C) *candidclient.Client {
+	client, err := candidclient.New(candidclient.NewParams{
+		BaseURL: s.URL,
+		Client: &httpbakery.Client{
+			Client: httpbakery.NewHTTPClient(),
+			Key:    s.adminAgentKey,
+		},
+		AgentUsername: auth.AdminUsername,
+	})
+	c.Assert(err, gc.Equals, nil)
+	return client
+}
+
+// CreateAgent creates a new agent user in the identity server's store
+// with the given name and groups. The agent's username and key are
+// returned.
+//
+// The agent will be owned by admin@candid.
+func (s *ServerSuite) CreateAgent(c *gc.C, username string, groups ...string) *bakery.KeyPair {
+	key, err := bakery.GenerateKey()
+	c.Assert(err, gc.Equals, nil)
+	name := strings.TrimSuffix(username, "@candid")
+	if name == username {
+		c.Fatalf("agent username must end in @candid")
+	}
+	err = s.Params.Store.UpdateIdentity(
+		context.Background(),
+		&store.Identity{
+			ProviderID: store.MakeProviderIdentity("idm", name),
+			Username:   username,
+			Groups:     groups,
+			PublicKeys: []bakery.PublicKey{
+				key.Public,
+			},
+			Owner: auth.AdminProviderID,
+		},
+		store.Update{
+			store.Username:   store.Set,
+			store.Groups:     store.Set,
+			store.PublicKeys: store.Set,
+			store.Owner:      store.Set,
+		},
+	)
+	c.Assert(err, gc.Equals, nil)
+	return key
+}
+
+// CreateUser creates a new user in the identity server's store with the
+// given name and groups. The user's username is returned.
+func (s *ServerSuite) CreateUser(c *gc.C, name string, groups ...string) string {
+	err := s.Params.Store.UpdateIdentity(
+		context.Background(),
+		&store.Identity{
+			ProviderID: store.MakeProviderIdentity("test", name),
+			Username:   name,
+			Groups:     groups,
+		},
+		store.Update{
+			store.Username: store.Set,
+			store.Groups:   store.Set,
+		},
+	)
+	c.Assert(err, gc.Equals, nil)
+	return name
+}
+
+// IdentityClient creates a new agent with the given username
+// (which must end in @candid) and groups and then creates an
+// candidclient.Client
+// which authenticates using that agent.
+func (s *ServerSuite) IdentityClient(c *gc.C, username string, groups ...string) *candidclient.Client {
+	key := s.CreateAgent(c, username, groups...)
+	client, err := candidclient.New(candidclient.NewParams{
+		BaseURL: s.URL,
+		Client: &httpbakery.Client{
+			Client: httpbakery.NewHTTPClient(),
+			Key:    key,
+		},
+		AgentUsername: username,
+	})
+	c.Assert(err, gc.Equals, nil)
+	return client
+}
+
+// Do is a convenience function for performing HTTP requests against the
+// server. The server's URL will be prepended to the one specified in the
+// request and then the request will be performed using
+// http.DefaultClient.
+func (s *ServerSuite) Do(c *gc.C, req *http.Request) *http.Response {
+	resp, err := http.DefaultClient.Do(s.reqUrl(c, req))
+	c.Assert(err, gc.Equals, nil)
+	return resp
+}
+
+// Get is a convenience function for performing HTTP requests against the
+// server. The server's URL will be prepended to the one given and then
+// the GET will be performed using http.DefaultClient.
+func (s *ServerSuite) Get(c *gc.C, url string) *http.Response {
+	req, err := http.NewRequest("GET", url, nil)
+	c.Assert(err, gc.Equals, nil)
+	return s.Do(c, req)
+}
+
+// RoundTrip is a convenience function for performing a single HTTP
+// requests against the server. The server's URL will be prepended to the
+// one specified in the request and then a single request will be
+// performed using http.DefaultTransport.
+func (s *ServerSuite) RoundTrip(c *gc.C, req *http.Request) *http.Response {
+	resp, err := http.DefaultTransport.RoundTrip(s.reqUrl(c, req))
+	c.Assert(err, gc.Equals, nil)
+	return resp
+}
+
+func (s *ServerSuite) reqUrl(c *gc.C, req *http.Request) *http.Request {
+	u, err := url.Parse(s.URL)
+	c.Assert(err, gc.Equals, nil)
+	req.URL = u.ResolveReference(req.URL)
+	return req
+}
+
+// NoVisit is a httpbakery.Visitor that returns an error without
+// attempting a visit.
+type NoVisit struct{}
+
+// VisitWebPage implements httpbakery.Visitor.VisitWebPage
+func (NoVisit) VisitWebPage(context.Context, *httpbakery.Client, map[string]*url.URL) error {
+	return errgo.New("visit not supported")
+}

--- a/internal/qtcandidtest/server.go
+++ b/internal/qtcandidtest/server.go
@@ -10,9 +10,9 @@ import (
 	"net/url"
 	"strings"
 
+	qt "github.com/frankban/quicktest"
 	"golang.org/x/net/context"
 	"gopkg.in/CanonicalLtd/candidclient.v1"
-	gc "gopkg.in/check.v1"
 	errgo "gopkg.in/errgo.v1"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon-bakery.v2/httpbakery"
@@ -21,7 +21,7 @@ import (
 	"github.com/CanonicalLtd/candid/internal/auth"
 	"github.com/CanonicalLtd/candid/internal/identity"
 	"github.com/CanonicalLtd/candid/store"
-	"github.com/juju/aclstore/v2"
+	aclstore "github.com/juju/aclstore/v2"
 	"github.com/juju/simplekv/memsimplekv"
 )
 
@@ -33,19 +33,8 @@ func init() {
 
 const loginTemplate = "login successful as user {{.Username}}\n"
 
-// A ServerSuite is a test suite that
-type ServerSuite struct {
-	// Params is used to configure the server. Any settings must be
-	// set before calling SetUpTest. At the least Store, MeetingStore
-	// and RootKeyStore must be configured.
-	Params identity.ServerParams
-
-	// Versions configures the API versions which will be served by
-	// the server. This must be set before calling SetUpTest.
-	Versions map[string]identity.NewAPIHandlerFunc
-
-	// The following fields will be available after calling SetUpTest.
-
+// Server implements a test fixture that contains a candid server.
+type Server struct {
 	// URL contains the URL of the server.
 	URL string
 
@@ -53,8 +42,7 @@ type ServerSuite struct {
 	// the servers.
 	Ctx context.Context
 
-	// params contains the final parameters that were passed to
-	// identity.New.
+	// params contains the parameters that were passed to identity.New.
 	params            identity.ServerParams
 	handler           *identity.Server
 	server            *httptest.Server
@@ -64,25 +52,33 @@ type ServerSuite struct {
 	agentID           int
 }
 
-// SetUpTest creates a new identity server and serves it. The server is
-// configured based on the Params and Versions fields. If the Key
-// parameter is not set then a new key will be generated. If the
-// PrivateAddr parameter is not set then it will default to localhost. If
-// the adminAgentPublicKey is not set then a new key will be generated,
-// note that if it is set the AdminClient and AdminIdentityClient can not
-// be used. If the Template parameter is not set then DefaultTemplate
-// will be used.
-func (s *ServerSuite) SetUpTest(c *gc.C) {
-	s.params = s.Params
+// NewMemServer returns a Server instance
+// that uses in-memory storage and serves
+// the given API version
+func NewMemServer(c *qt.C, versions map[string]identity.NewAPIHandlerFunc) *Server {
+	return NewServer(c, NewStore().ServerParams(), versions)
+}
+
+// NewServer returns new Server instance. The server parameters must
+// contain at least Store, MeetingStore and RootKeyStore. The versions
+// argument configures what API versions to serve.
+//
+// If p.Key is zero then a new key will be generated. If p.PrivateAddr
+// is zero then it will default to localhost. If p.Template is zero then
+// DefaultTemplate will be used.
+func NewServer(c *qt.C, p identity.ServerParams, versions map[string]identity.NewAPIHandlerFunc) *Server {
+	s := new(Server)
+	s.params = p
 	if s.params.ACLStore == nil {
 		s.params.ACLStore = aclstore.NewACLStore(memsimplekv.NewStore())
 	}
 	s.server = httptest.NewUnstartedServer(nil)
+	c.Defer(s.server.Close)
 	s.params.Location = "http://" + s.server.Listener.Addr().String()
 	if s.params.Key == nil {
 		var err error
 		s.params.Key, err = bakery.GenerateKey()
-		c.Assert(err, gc.Equals, nil)
+		c.Assert(err, qt.Equals, nil)
 	}
 	if s.params.PrivateAddr == "" {
 		s.params.PrivateAddr = "localhost"
@@ -90,34 +86,33 @@ func (s *ServerSuite) SetUpTest(c *gc.C) {
 	if s.params.AdminAgentPublicKey == nil {
 		var err error
 		s.adminAgentKey, err = bakery.GenerateKey()
-		c.Assert(err, gc.Equals, nil)
+		c.Assert(err, qt.Equals, nil)
 		s.params.AdminAgentPublicKey = &s.adminAgentKey.Public
 	}
 	if s.params.Template == nil {
 		s.params.Template = DefaultTemplate
 	}
 	var err error
-	s.handler, err = identity.New(s.params, s.Versions)
-	c.Assert(err, gc.Equals, nil)
+	s.handler, err = identity.New(s.params, versions)
+	c.Assert(err, qt.Equals, nil)
+	c.Defer(s.handler.Close)
 
 	s.server.Config.Handler = s.handler
 	s.server.Start()
 	s.URL = s.server.URL
-	s.Ctx, s.closeStore = s.Params.Store.Context(context.Background())
-	s.Ctx, s.closeMeetingStore = s.Params.MeetingStore.Context(context.Background())
-}
+	ctx := context.Background()
+	ctx, closeStore := s.params.Store.Context(ctx)
+	c.Defer(closeStore)
 
-// TearDownTest cleans up the resources created during SetUpTest.
-func (s *ServerSuite) TearDownTest(c *gc.C) {
-	s.closeMeetingStore()
-	s.closeStore()
-	s.server.Close()
-	s.handler.Close()
+	ctx, closeMeetingStore := s.params.MeetingStore.Context(ctx)
+	c.Defer(closeMeetingStore)
+	s.Ctx = ctx
+	return s
 }
 
 // ThirdPartyInfo implements bakery.ThirdPartyLocator.THirdPartyInfo
 // allowing the suite to be used as a bakery.ThirdPArtyLocator.
-func (s *ServerSuite) ThirdPartyInfo(ctx context.Context, loc string) (bakery.ThirdPartyInfo, error) {
+func (s *Server) ThirdPartyInfo(ctx context.Context, loc string) (bakery.ThirdPartyInfo, error) {
 	if loc != s.URL {
 		return bakery.ThirdPartyInfo{}, bakery.ErrNotFound
 	}
@@ -127,10 +122,16 @@ func (s *ServerSuite) ThirdPartyInfo(ctx context.Context, loc string) (bakery.Th
 	}, nil
 }
 
-// Client creates a new httpbakery.Client which uses the given visitor as
+// Client is a convenience method that returns the result of
+// calling BakeryClient(i)
+func (s *Server) Client(i httpbakery.Interactor) *httpbakery.Client {
+	return BakeryClient(i)
+}
+
+// BakeryClient creates a new httpbakery.Client which uses the given visitor as
 // its WebPageVisitor. If no Visitor is specified then NoVisit will be
 // used.
-func (s *ServerSuite) Client(i httpbakery.Interactor) *httpbakery.Client {
+func BakeryClient(i httpbakery.Interactor) *httpbakery.Client {
 	cl := &httpbakery.Client{
 		Client: httpbakery.NewHTTPClient(),
 	}
@@ -142,7 +143,7 @@ func (s *ServerSuite) Client(i httpbakery.Interactor) *httpbakery.Client {
 
 // AdminClient creates a new httpbakery.Client that is configured to log
 // in as an admin user.
-func (s *ServerSuite) AdminClient() *httpbakery.Client {
+func (s *Server) AdminClient() *httpbakery.Client {
 	client := &httpbakery.Client{
 		Client: httpbakery.NewHTTPClient(),
 		Key:    s.adminAgentKey,
@@ -159,7 +160,7 @@ func (s *ServerSuite) AdminClient() *httpbakery.Client {
 
 // AdminIdentityClient creates a new candidclient.Client that is configured to log
 // in as an admin user.
-func (s *ServerSuite) AdminIdentityClient(c *gc.C) *candidclient.Client {
+func (s *Server) AdminIdentityClient() *candidclient.Client {
 	client, err := candidclient.New(candidclient.NewParams{
 		BaseURL: s.URL,
 		Client: &httpbakery.Client{
@@ -168,7 +169,9 @@ func (s *ServerSuite) AdminIdentityClient(c *gc.C) *candidclient.Client {
 		},
 		AgentUsername: auth.AdminUsername,
 	})
-	c.Assert(err, gc.Equals, nil)
+	if err != nil {
+		panic(err)
+	}
 	return client
 }
 
@@ -177,14 +180,14 @@ func (s *ServerSuite) AdminIdentityClient(c *gc.C) *candidclient.Client {
 // returned.
 //
 // The agent will be owned by admin@candid.
-func (s *ServerSuite) CreateAgent(c *gc.C, username string, groups ...string) *bakery.KeyPair {
+func (s *Server) CreateAgent(c *qt.C, username string, groups ...string) *bakery.KeyPair {
 	key, err := bakery.GenerateKey()
-	c.Assert(err, gc.Equals, nil)
+	c.Assert(err, qt.Equals, nil)
 	name := strings.TrimSuffix(username, "@candid")
 	if name == username {
 		c.Fatalf("agent username must end in @candid")
 	}
-	err = s.Params.Store.UpdateIdentity(
+	err = s.params.Store.UpdateIdentity(
 		context.Background(),
 		&store.Identity{
 			ProviderID: store.MakeProviderIdentity("idm", name),
@@ -202,14 +205,14 @@ func (s *ServerSuite) CreateAgent(c *gc.C, username string, groups ...string) *b
 			store.Owner:      store.Set,
 		},
 	)
-	c.Assert(err, gc.Equals, nil)
+	c.Assert(err, qt.Equals, nil)
 	return key
 }
 
 // CreateUser creates a new user in the identity server's store with the
 // given name and groups. The user's username is returned.
-func (s *ServerSuite) CreateUser(c *gc.C, name string, groups ...string) string {
-	err := s.Params.Store.UpdateIdentity(
+func (s *Server) CreateUser(c *qt.C, name string, groups ...string) string {
+	err := s.params.Store.UpdateIdentity(
 		context.Background(),
 		&store.Identity{
 			ProviderID: store.MakeProviderIdentity("test", name),
@@ -221,7 +224,7 @@ func (s *ServerSuite) CreateUser(c *gc.C, name string, groups ...string) string 
 			store.Groups:   store.Set,
 		},
 	)
-	c.Assert(err, gc.Equals, nil)
+	c.Assert(err, qt.Equals, nil)
 	return name
 }
 
@@ -229,7 +232,7 @@ func (s *ServerSuite) CreateUser(c *gc.C, name string, groups ...string) string 
 // (which must end in @candid) and groups and then creates an
 // candidclient.Client
 // which authenticates using that agent.
-func (s *ServerSuite) IdentityClient(c *gc.C, username string, groups ...string) *candidclient.Client {
+func (s *Server) IdentityClient(c *qt.C, username string, groups ...string) *candidclient.Client {
 	key := s.CreateAgent(c, username, groups...)
 	client, err := candidclient.New(candidclient.NewParams{
 		BaseURL: s.URL,
@@ -239,7 +242,7 @@ func (s *ServerSuite) IdentityClient(c *gc.C, username string, groups ...string)
 		},
 		AgentUsername: username,
 	})
-	c.Assert(err, gc.Equals, nil)
+	c.Assert(err, qt.Equals, nil)
 	return client
 }
 
@@ -247,18 +250,18 @@ func (s *ServerSuite) IdentityClient(c *gc.C, username string, groups ...string)
 // server. The server's URL will be prepended to the one specified in the
 // request and then the request will be performed using
 // http.DefaultClient.
-func (s *ServerSuite) Do(c *gc.C, req *http.Request) *http.Response {
+func (s *Server) Do(c *qt.C, req *http.Request) *http.Response {
 	resp, err := http.DefaultClient.Do(s.reqUrl(c, req))
-	c.Assert(err, gc.Equals, nil)
+	c.Assert(err, qt.Equals, nil)
 	return resp
 }
 
 // Get is a convenience function for performing HTTP requests against the
 // server. The server's URL will be prepended to the one given and then
 // the GET will be performed using http.DefaultClient.
-func (s *ServerSuite) Get(c *gc.C, url string) *http.Response {
+func (s *Server) Get(c *qt.C, url string) *http.Response {
 	req, err := http.NewRequest("GET", url, nil)
-	c.Assert(err, gc.Equals, nil)
+	c.Assert(err, qt.Equals, nil)
 	return s.Do(c, req)
 }
 
@@ -266,15 +269,15 @@ func (s *ServerSuite) Get(c *gc.C, url string) *http.Response {
 // requests against the server. The server's URL will be prepended to the
 // one specified in the request and then a single request will be
 // performed using http.DefaultTransport.
-func (s *ServerSuite) RoundTrip(c *gc.C, req *http.Request) *http.Response {
+func (s *Server) RoundTrip(c *qt.C, req *http.Request) *http.Response {
 	resp, err := http.DefaultTransport.RoundTrip(s.reqUrl(c, req))
-	c.Assert(err, gc.Equals, nil)
+	c.Assert(err, qt.Equals, nil)
 	return resp
 }
 
-func (s *ServerSuite) reqUrl(c *gc.C, req *http.Request) *http.Request {
+func (s *Server) reqUrl(c *qt.C, req *http.Request) *http.Request {
 	u, err := url.Parse(s.URL)
-	c.Assert(err, gc.Equals, nil)
+	c.Assert(err, qt.Equals, nil)
 	req.URL = u.ResolveReference(req.URL)
 	return req
 }

--- a/internal/qtcandidtest/store.go
+++ b/internal/qtcandidtest/store.go
@@ -1,0 +1,107 @@
+// Copyright 2017 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package candidtest
+
+import (
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/juju/aclstore/v2"
+	"github.com/juju/simplekv/memsimplekv"
+	"github.com/juju/testing"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+
+	"github.com/CanonicalLtd/candid/meeting"
+	"github.com/CanonicalLtd/candid/store"
+	"github.com/CanonicalLtd/candid/store/memstore"
+)
+
+// A StoreSuite is a test suite that initializes a store.Store,
+// meeting.MeetingStore and bakery.RootKeyStore for use with tests.
+type StoreSuite struct {
+	testing.IsolationSuite
+
+	// The following stores will be initialised after calling SetUpTest
+
+	Store              store.Store
+	ProviderDataStore  store.ProviderDataStore
+	MeetingStore       meeting.Store
+	BakeryRootKeyStore bakery.RootKeyStore
+	ACLStore           aclstore.ACLStore
+}
+
+func (s *StoreSuite) SetUpSuite(c *gc.C) {
+	s.IsolationSuite.SetUpSuite(c)
+}
+
+func (s *StoreSuite) TearDownSuite(c *gc.C) {
+	s.IsolationSuite.TearDownSuite(c)
+}
+
+func (s *StoreSuite) SetUpTest(c *gc.C) {
+	s.IsolationSuite.SetUpTest(c)
+	s.Store = memstore.NewStore()
+	s.ProviderDataStore = memstore.NewProviderDataStore()
+	s.MeetingStore = memstore.NewMeetingStore()
+	s.BakeryRootKeyStore = bakery.NewMemRootKeyStore()
+	s.ACLStore = aclstore.NewACLStore(memsimplekv.NewStore())
+}
+
+func (s *StoreSuite) TearDownTest(c *gc.C) {
+	s.IsolationSuite.TearDownTest(c)
+}
+
+// A StoreServerSuite combines a StoreSuite and a ServerSuite to provider
+// an initialized server with storage.
+type StoreServerSuite struct {
+	StoreSuite
+	ServerSuite
+}
+
+func (s *StoreServerSuite) SetUpTest(c *gc.C) {
+	s.StoreSuite.SetUpTest(c)
+	s.Params.Store = s.Store
+	s.Params.ProviderDataStore = s.ProviderDataStore
+	s.Params.MeetingStore = s.MeetingStore
+	s.Params.RootKeyStore = s.BakeryRootKeyStore
+	s.Params.ACLStore = s.ACLStore
+	s.ServerSuite.SetUpTest(c)
+}
+
+func (s *StoreServerSuite) TearDownTest(c *gc.C) {
+	s.ServerSuite.TearDownTest(c)
+	s.StoreSuite.TearDownTest(c)
+}
+
+// AssertEqualIdentity asserts that the two provided identites are
+// semantically equivilent.
+func AssertEqualIdentity(c *gc.C, obtained, expected *store.Identity) {
+	if expected.ID == "" {
+		obtained.ID = ""
+	}
+	normalizeInfoMap(obtained.ProviderInfo)
+	normalizeInfoMap(obtained.ExtraInfo)
+	normalizeInfoMap(expected.ProviderInfo)
+	normalizeInfoMap(expected.ExtraInfo)
+	opts := []cmp.Option{
+		cmpopts.EquateEmpty(),
+		cmpopts.SortSlices(func(s, t string) bool { return s < t }),
+		cmpopts.SortSlices(func(x, y bakery.PublicKey) bool { return string(x.Key[:]) < string(y.Key[:]) }),
+	}
+	msg := cmp.Diff(obtained, expected, opts...)
+	if msg != "" {
+		c.Fatalf("identities do not match: %s", msg)
+	}
+}
+
+// normalizeInfoMap normalizes a providerInfo or extraInfo map by
+// removing any keys that have a 0 length value.
+func normalizeInfoMap(m map[string][]string) {
+	for k, v := range m {
+		if len(v) == 0 {
+			delete(m, k)
+		}
+	}
+
+}

--- a/internal/qtcandidtest/store.go
+++ b/internal/qtcandidtest/store.go
@@ -17,8 +17,8 @@ import (
 	"github.com/CanonicalLtd/candid/store/memstore"
 )
 
-// Store implements a test fixture that contains a a store.Store,
-// meeting.MeetingStore and bakery.RootKeyStore for use with tests.
+// Store implements a test fixture that contains memory-based
+// store implementations for use with tests.
 type Store struct {
 	Store              store.Store
 	ProviderDataStore  store.ProviderDataStore

--- a/internal/qtcandidtest/store.go
+++ b/internal/qtcandidtest/store.go
@@ -6,24 +6,20 @@ package candidtest
 import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/juju/aclstore/v2"
+	aclstore "github.com/juju/aclstore/v2"
 	"github.com/juju/simplekv/memsimplekv"
-	"github.com/juju/testing"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 
+	"github.com/CanonicalLtd/candid/internal/identity"
 	"github.com/CanonicalLtd/candid/meeting"
 	"github.com/CanonicalLtd/candid/store"
 	"github.com/CanonicalLtd/candid/store/memstore"
 )
 
-// A StoreSuite is a test suite that initializes a store.Store,
+// Store implements a test fixture that contains a a store.Store,
 // meeting.MeetingStore and bakery.RootKeyStore for use with tests.
-type StoreSuite struct {
-	testing.IsolationSuite
-
-	// The following stores will be initialised after calling SetUpTest
-
+type Store struct {
 	Store              store.Store
 	ProviderDataStore  store.ProviderDataStore
 	MeetingStore       meeting.Store
@@ -31,47 +27,27 @@ type StoreSuite struct {
 	ACLStore           aclstore.ACLStore
 }
 
-func (s *StoreSuite) SetUpSuite(c *gc.C) {
-	s.IsolationSuite.SetUpSuite(c)
+// NewStore returns a new Store that uses in-memory storage.
+func NewStore() *Store {
+	return &Store{
+		Store:              memstore.NewStore(),
+		ProviderDataStore:  memstore.NewProviderDataStore(),
+		MeetingStore:       memstore.NewMeetingStore(),
+		BakeryRootKeyStore: bakery.NewMemRootKeyStore(),
+		ACLStore:           aclstore.NewACLStore(memsimplekv.NewStore()),
+	}
 }
 
-func (s *StoreSuite) TearDownSuite(c *gc.C) {
-	s.IsolationSuite.TearDownSuite(c)
-}
-
-func (s *StoreSuite) SetUpTest(c *gc.C) {
-	s.IsolationSuite.SetUpTest(c)
-	s.Store = memstore.NewStore()
-	s.ProviderDataStore = memstore.NewProviderDataStore()
-	s.MeetingStore = memstore.NewMeetingStore()
-	s.BakeryRootKeyStore = bakery.NewMemRootKeyStore()
-	s.ACLStore = aclstore.NewACLStore(memsimplekv.NewStore())
-}
-
-func (s *StoreSuite) TearDownTest(c *gc.C) {
-	s.IsolationSuite.TearDownTest(c)
-}
-
-// A StoreServerSuite combines a StoreSuite and a ServerSuite to provider
-// an initialized server with storage.
-type StoreServerSuite struct {
-	StoreSuite
-	ServerSuite
-}
-
-func (s *StoreServerSuite) SetUpTest(c *gc.C) {
-	s.StoreSuite.SetUpTest(c)
-	s.Params.Store = s.Store
-	s.Params.ProviderDataStore = s.ProviderDataStore
-	s.Params.MeetingStore = s.MeetingStore
-	s.Params.RootKeyStore = s.BakeryRootKeyStore
-	s.Params.ACLStore = s.ACLStore
-	s.ServerSuite.SetUpTest(c)
-}
-
-func (s *StoreServerSuite) TearDownTest(c *gc.C) {
-	s.ServerSuite.TearDownTest(c)
-	s.StoreSuite.TearDownTest(c)
+// ServerParams returns parameters suitable for passing
+// to NewServer that will use s as its store.
+func (s *Store) ServerParams() identity.ServerParams {
+	return identity.ServerParams{
+		Store:             s.Store,
+		ProviderDataStore: s.ProviderDataStore,
+		MeetingStore:      s.MeetingStore,
+		RootKeyStore:      s.BakeryRootKeyStore,
+		ACLStore:          s.ACLStore,
+	}
 }
 
 // AssertEqualIdentity asserts that the two provided identites are

--- a/store/memstore/config_test.go
+++ b/store/memstore/config_test.go
@@ -1,8 +1,9 @@
 package memstore_test
 
 import (
-	storetesting "github.com/CanonicalLtd/candid/store/testing"
 	gc "gopkg.in/check.v1"
+
+	storetesting "github.com/CanonicalLtd/candid/store/testing"
 )
 
 var _ = gc.Suite(&configSuite{})

--- a/store/memstore/keyvalue.go
+++ b/store/memstore/keyvalue.go
@@ -6,11 +6,11 @@ package memstore
 import (
 	"sync"
 
+	"github.com/juju/simplekv"
+	"github.com/juju/simplekv/memsimplekv"
 	"golang.org/x/net/context"
 
 	"github.com/CanonicalLtd/candid/store"
-	"github.com/juju/simplekv"
-	"github.com/juju/simplekv/memsimplekv"
 )
 
 // NewProviderDataStore creates a new in-memory store.ProviderDataStore.

--- a/store/mgostore/config_test.go
+++ b/store/mgostore/config_test.go
@@ -3,6 +3,7 @@ package mgostore_test
 import (
 	"os"
 
+	"github.com/juju/mgotest"
 	gc "gopkg.in/check.v1"
 	errgo "gopkg.in/errgo.v1"
 	"gopkg.in/yaml.v2"
@@ -10,7 +11,6 @@ import (
 	"github.com/CanonicalLtd/candid/store"
 	"github.com/CanonicalLtd/candid/store/mgostore"
 	storetesting "github.com/CanonicalLtd/candid/store/testing"
-	"github.com/juju/mgotest"
 )
 
 var _ = gc.Suite(&configSuite{})

--- a/store/mgostore/keyvalue.go
+++ b/store/mgostore/keyvalue.go
@@ -4,10 +4,9 @@
 package mgostore
 
 import (
-	"golang.org/x/net/context"
-
 	"github.com/juju/simplekv"
 	"github.com/juju/simplekv/mgosimplekv"
+	"golang.org/x/net/context"
 )
 
 // an providerDataStore implements store.ProviderDataStore.

--- a/store/sqlstore/config_test.go
+++ b/store/sqlstore/config_test.go
@@ -1,10 +1,11 @@
 package sqlstore_test
 
 import (
-	storetesting "github.com/CanonicalLtd/candid/store/testing"
 	"github.com/juju/postgrestest"
 	gc "gopkg.in/check.v1"
 	errgo "gopkg.in/errgo.v1"
+
+	storetesting "github.com/CanonicalLtd/candid/store/testing"
 )
 
 var _ = gc.Suite(&configSuite{})

--- a/store/testing/config.go
+++ b/store/testing/config.go
@@ -3,10 +3,11 @@ package testing
 import (
 	"time"
 
-	"github.com/CanonicalLtd/candid/store"
 	"golang.org/x/net/context"
 	gc "gopkg.in/check.v1"
 	"gopkg.in/yaml.v2"
+
+	"github.com/CanonicalLtd/candid/store"
 )
 
 func TestUnmarshal(c *gc.C, configYAML string) {

--- a/store/testing/keyvalue.go
+++ b/store/testing/keyvalue.go
@@ -6,12 +6,12 @@ package testing
 import (
 	"time"
 
+	"github.com/juju/simplekv"
 	"golang.org/x/net/context"
 	gc "gopkg.in/check.v1"
 	errgo "gopkg.in/errgo.v1"
 
 	"github.com/CanonicalLtd/candid/store"
-	"github.com/juju/simplekv"
 )
 
 // KeyValueSuite contains a set of tests for KeyValueStore implementations. The


### PR DESCRIPTION
This PR copies candidtest to qtcandidtest (first commit), then adapts it to use quicktest, and does a partial conversion of one package by way of proof-of-concept (second commit).

Once we've converted all the other tests, we can rename qtcandidtest back to candidtest.
