### PR TITLE
qtidptest: copy and convert from idptest

### DIFF
--- a/idp/qtidptest/suite.go
+++ b/idp/qtidptest/suite.go
@@ -1,0 +1,187 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package idptest
+
+import (
+	"html/template"
+	"net/http"
+
+	"golang.org/x/net/context"
+	gc "gopkg.in/check.v1"
+	"gopkg.in/macaroon-bakery.v2/bakery"
+	"gopkg.in/macaroon-bakery.v2/httpbakery"
+
+	"github.com/CanonicalLtd/candid/idp"
+	"github.com/CanonicalLtd/candid/internal/candidtest"
+	"github.com/CanonicalLtd/candid/store"
+)
+
+// Suite provides a test suite that is helpful for testing identity
+// providers.
+type Suite struct {
+	StoreSuite candidtest.StoreSuite
+
+	// template contains a template that will be passed in the
+	// idp.InitParams.
+	template *template.Template
+
+	// The following fields will be available after calling SetUpTest.
+
+	// Ctx contains a context.Context that has been initialised with
+	// the stores.
+	Ctx context.Context
+
+	// Oven contains a bakery.Oven that will be passed in the
+	// idp.InitParams. Tests can use this to mint macaroons if
+	// necessary.
+	Oven *bakery.Oven
+
+	dischargeTokenCreator *dischargeTokenCreator
+	visitCompleter        *visitCompleter
+	closeStore            func()
+	closeMeetingStore     func()
+}
+
+func (s *Suite) SetUpSuite(c *gc.C) {
+	s.StoreSuite.SetUpSuite(c)
+}
+
+func (s *Suite) TearDownSuite(c *gc.C) {
+	s.StoreSuite.TearDownSuite(c)
+}
+
+func (s *Suite) SetUpTest(c *gc.C) {
+	s.StoreSuite.SetUpTest(c)
+	s.Ctx, s.closeStore = s.StoreSuite.Store.Context(context.Background())
+	s.Ctx, s.closeMeetingStore = s.StoreSuite.MeetingStore.Context(s.Ctx)
+	key, err := bakery.GenerateKey()
+	c.Assert(err, gc.Equals, nil)
+	s.Oven = bakery.NewOven(bakery.OvenParams{
+		Key:      key,
+		Location: "idptest",
+	})
+}
+
+func (s *Suite) TearDownTest(c *gc.C) {
+	s.closeMeetingStore()
+	s.closeStore()
+	s.StoreSuite.TearDownTest(c)
+}
+
+// InitParams returns a completed InitParams that a test can use to pass
+// to idp.Init.
+func (s *Suite) InitParams(c *gc.C, prefix string) idp.InitParams {
+	s.dischargeTokenCreator = &dischargeTokenCreator{}
+	s.visitCompleter = &visitCompleter{
+		c: c,
+	}
+	kv, err := s.StoreSuite.ProviderDataStore.KeyValueStore(s.Ctx, "idptest")
+	c.Assert(err, gc.Equals, nil)
+	return idp.InitParams{
+		Store:                 s.StoreSuite.Store,
+		KeyValueStore:         kv,
+		Oven:                  s.Oven,
+		Key:                   s.Oven.Key(),
+		URLPrefix:             prefix,
+		DischargeTokenCreator: s.dischargeTokenCreator,
+		VisitCompleter:        s.visitCompleter,
+		Template:              s.template,
+	}
+}
+
+// AssertLoginSuccess asserts that the login test has resulted in a
+// successful login of the given user.
+func (s *Suite) AssertLoginSuccess(c *gc.C, username string) {
+	c.Assert(s.visitCompleter.called, gc.Equals, true)
+	c.Check(s.visitCompleter.err, gc.Equals, nil)
+	c.Assert(s.visitCompleter.id, gc.NotNil)
+	c.Assert(s.visitCompleter.id.Username, gc.Equals, username)
+}
+
+// AssertLoginFailure asserts taht the login test has resulted in a
+// failure with an error that matches the given regex.
+func (s *Suite) AssertLoginFailureMatches(c *gc.C, regex string) {
+	c.Assert(s.visitCompleter.called, gc.Equals, true)
+	c.Assert(s.visitCompleter.err, gc.ErrorMatches, regex)
+}
+
+// AssertLoginNotComplete asserts that the login attempt has not yet
+// completed.
+func (s *Suite) AssertLoginNotComplete(c *gc.C) {
+	c.Assert(s.visitCompleter.called, gc.Equals, false)
+}
+
+// AssertUser asserts that the specified user is stored in the store.
+// It returns the stored identity.
+func (s *Suite) AssertUser(c *gc.C, id *store.Identity) *store.Identity {
+	id1 := store.Identity{
+		ProviderID: id.ProviderID,
+		Username:   id.Username,
+	}
+	err := s.StoreSuite.Store.Identity(s.Ctx, &id1)
+	c.Assert(err, gc.Equals, nil)
+	candidtest.AssertEqualIdentity(c, &id1, id)
+	return &id1
+}
+
+type visitCompleter struct {
+	c           *gc.C
+	called      bool
+	dischargeID string
+	returnTo    string
+	state       string
+	id          *store.Identity
+	err         error
+}
+
+func (l *visitCompleter) Success(_ context.Context, _ http.ResponseWriter, _ *http.Request, dischargeID string, id *store.Identity) {
+	if l.called {
+		l.c.Error("login completion method called more that once")
+		return
+	}
+	l.called = true
+	l.dischargeID = dischargeID
+	l.id = id
+}
+
+func (l *visitCompleter) Failure(_ context.Context, _ http.ResponseWriter, _ *http.Request, dischargeID string, err error) {
+	if l.called {
+		l.c.Error("login completion method called more that once")
+		return
+	}
+	l.called = true
+	l.dischargeID = dischargeID
+	l.err = err
+}
+
+func (l *visitCompleter) RedirectSuccess(_ context.Context, _ http.ResponseWriter, _ *http.Request, returnTo, state string, id *store.Identity) {
+	if l.called {
+		l.c.Error("login completion method called more that once")
+		return
+	}
+	l.called = true
+	l.returnTo = returnTo
+	l.state = state
+	l.id = id
+}
+
+func (l *visitCompleter) RedirectFailure(_ context.Context, _ http.ResponseWriter, _ *http.Request, returnTo, state string, err error) {
+	if l.called {
+		l.c.Error("login completion method called more that once")
+		return
+	}
+	l.called = true
+	l.returnTo = returnTo
+	l.state = state
+	l.err = err
+}
+
+type dischargeTokenCreator struct{}
+
+func (d *dischargeTokenCreator) DischargeToken(_ context.Context, id *store.Identity) (*httpbakery.DischargeToken, error) {
+	return &httpbakery.DischargeToken{
+		Kind:  "test",
+		Value: []byte(id.Username),
+	}, nil
+}

--- a/internal/qtcandidtest/store.go
+++ b/internal/qtcandidtest/store.go
@@ -4,11 +4,12 @@
 package candidtest
 
 import (
+	qt "github.com/frankban/quicktest"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	aclstore "github.com/juju/aclstore/v2"
 	"github.com/juju/simplekv/memsimplekv"
-	gc "gopkg.in/check.v1"
+	"golang.org/x/net/context"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 
 	"github.com/CanonicalLtd/candid/internal/identity"
@@ -50,9 +51,22 @@ func (s *Store) ServerParams() identity.ServerParams {
 	}
 }
 
+// AssertUser asserts that the specified user is stored in the store.
+// It returns the stored identity.
+func (s *Store) AssertUser(c *qt.C, id *store.Identity) *store.Identity {
+	id1 := store.Identity{
+		ProviderID: id.ProviderID,
+		Username:   id.Username,
+	}
+	err := s.Store.Identity(context.Background(), &id1)
+	c.Assert(err, qt.Equals, nil)
+	AssertEqualIdentity(c, &id1, id)
+	return &id1
+}
+
 // AssertEqualIdentity asserts that the two provided identites are
 // semantically equivilent.
-func AssertEqualIdentity(c *gc.C, obtained, expected *store.Identity) {
+func AssertEqualIdentity(c *qt.C, obtained, expected *store.Identity) {
 	if expected.ID == "" {
 		obtained.ID = ""
 	}


### PR DESCRIPTION
Similar to candidtest, we create a quicktest version so that we can avoid
converting all the packages at once. We convert one test suite to show
what it looks like in use.
