### PR TITLE
all: avoid gc.IsNil for error checking

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -106,7 +106,7 @@ func (s *configSuite) readConfig(c *gc.C, content string) (*config.Config, error
 	// Write the configuration content to file.
 	path := path.Join(c.MkDir(), "config.yaml")
 	err := ioutil.WriteFile(path, []byte(content), 0666)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	// Read the configuration.
 	return config.Read(path)
@@ -117,7 +117,7 @@ func (s *configSuite) TestRead(c *gc.C) {
 	idp.Register("keystone", testIdentityProvider)
 	store.Register("test", testStorageBackend)
 	conf, err := s.readConfig(c, testConfig)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	// Check that the TLS configuration creates a valid *tls.Config
 	tlsConfig := conf.TLSConfig()
 	c.Assert(tlsConfig, gc.Not(gc.IsNil))
@@ -126,13 +126,13 @@ func (s *configSuite) TestRead(c *gc.C) {
 
 	var key bakery.KeyPair
 	err = key.Public.UnmarshalText([]byte("CIdWcEUN+0OZnKW9KwruRQnQDY/qqzVdD30CijwiWCk="))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = key.Private.UnmarshalText([]byte("8PjzjakvIlh3BVFKe8axinRDutF6EDIfjtuf4+JaNow="))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	var adminPubKey bakery.PublicKey
 	err = adminPubKey.UnmarshalText([]byte("dUnC8p9p3nygtE2h92a47Ooq0rXg0fVSm3YBWou5/UQ="))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	c.Assert(conf, jc.DeepEquals, &config.Config{
 		Storage: &store.Config{

--- a/idp/agent/agent_test.go
+++ b/idp/agent/agent_test.go
@@ -23,7 +23,7 @@ identity-providers:
 `
 	var conf config.Config
 	err := yaml.Unmarshal([]byte(configYaml), &conf)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(conf.IdentityProviders, gc.HasLen, 1)
 	c.Assert(conf.IdentityProviders[0].Name(), gc.Equals, "agent")
 }

--- a/idp/keystone/internal/keystone/params_test.go
+++ b/idp/keystone/internal/keystone/params_test.go
@@ -39,7 +39,7 @@ func (s *paramsSuite) TestTimeUnmarshalJSON(c *gc.C) {
 			c.Assert(err, gc.ErrorMatches, test.expectError)
 			continue
 		}
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		c.Assert(t.Equal(test.expect), gc.Equals, true, gc.Commentf("obtained: %#v, expected: %#v", t, test.expect))
 	}
 }

--- a/idp/keystone/token_test.go
+++ b/idp/keystone/token_test.go
@@ -67,9 +67,9 @@ func (s *tokenSuite) TestKeystoneTokenIdentityProviderHandle(c *gc.C) {
 	var tok keystoneidp.Token
 	tok.Login.ID = "789"
 	body, err := json.Marshal(tok)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	req, err := http.NewRequest("POST", "https://idp.test/login?did=1", bytes.NewReader(body))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	s.idp.Handle(s.Ctx, rr, req)
@@ -87,9 +87,9 @@ func (s *tokenSuite) TestKeystoneTokenIdentityProviderHandleBadToken(c *gc.C) {
 	var tok keystoneidp.Token
 	tok.Login.ID = "012"
 	body, err := json.Marshal(tok)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	req, err := http.NewRequest("POST", "https://idp.test/login?did=1", bytes.NewReader(body))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	s.idp.Handle(s.Ctx, rr, req)
@@ -98,7 +98,7 @@ func (s *tokenSuite) TestKeystoneTokenIdentityProviderHandleBadToken(c *gc.C) {
 
 func (s *tokenSuite) TestKeystoneTokenIdentityProviderHandleBadRequest(c *gc.C) {
 	req, err := http.NewRequest("POST", "https://idp.test/login?did=1", strings.NewReader("{"))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	s.idp.Handle(s.Ctx, rr, req)
@@ -114,7 +114,7 @@ identity-providers:
 `
 	var conf config.Config
 	err := yaml.Unmarshal([]byte(input), &conf)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(conf.IdentityProviders, gc.HasLen, 1)
 	c.Assert(conf.IdentityProviders[0].Name(), gc.Equals, "openstack3")
 }

--- a/idp/keystone/tokenv3_test.go
+++ b/idp/keystone/tokenv3_test.go
@@ -59,9 +59,9 @@ func (s *tokenV3Suite) TestKeystoneV3TokenIdentityProviderHandle(c *gc.C) {
 	var tok keystoneidp.Token
 	tok.Login.ID = "789"
 	body, err := json.Marshal(tok)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	req, err := http.NewRequest("POST", "/login?did=1", bytes.NewReader(body))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	s.idp.Handle(s.Ctx, rr, req)
@@ -79,9 +79,9 @@ func (s *tokenV3Suite) TestKeystoneV3TokenIdentityProviderHandleBadToken(c *gc.C
 	var tok keystoneidp.Token
 	tok.Login.ID = "012"
 	body, err := json.Marshal(tok)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	req, err := http.NewRequest("POST", "https://idp.test/login?did=1", bytes.NewReader(body))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	s.idp.Handle(s.Ctx, rr, req)
@@ -90,7 +90,7 @@ func (s *tokenV3Suite) TestKeystoneV3TokenIdentityProviderHandleBadToken(c *gc.C
 
 func (s *tokenV3Suite) TestKeystoneV3TokenIdentityProviderHandleBadRequest(c *gc.C) {
 	req, err := http.NewRequest("POST", "https://idp.test/login?did=1", strings.NewReader("{"))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	s.idp.Handle(s.Ctx, rr, req)
@@ -106,7 +106,7 @@ identity-providers:
 `
 	var conf config.Config
 	err := yaml.Unmarshal([]byte(input), &conf)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(conf.IdentityProviders, gc.HasLen, 1)
 	c.Assert(conf.IdentityProviders[0].Name(), gc.Equals, "openstackv3_3")
 }

--- a/idp/keystone/userpass_test.go
+++ b/idp/keystone/userpass_test.go
@@ -78,9 +78,9 @@ func (s *userpassSuite) TestKeystoneUserpassIdentityProviderHandleResponse(c *gc
 	body, err := json.Marshal(form.LoginBody{
 		Form: login,
 	})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	req, err := http.NewRequest("POST", "/login?did=1", bytes.NewReader(body))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	s.idp.Handle(s.Ctx, rr, req)
@@ -99,7 +99,7 @@ func (s *userpassSuite) TestKeystoneUserpassIdentityProviderHandleResponse(c *gc
 
 func (s *userpassSuite) TestKeystoneUserpassIdentityProviderHandleBadRequest(c *gc.C) {
 	req, err := http.NewRequest("POST", "/login?did=1", strings.NewReader("{"))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	s.idp.Handle(s.Ctx, rr, req)
@@ -113,9 +113,9 @@ func (s *userpassSuite) TestKeystoneUserpassIdentityProviderHandleNoUsername(c *
 	body, err := json.Marshal(form.LoginBody{
 		Form: login,
 	})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	req, err := http.NewRequest("POST", "https://idp.test/login?did=1", bytes.NewReader(body))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	s.idp.Handle(s.Ctx, rr, req)
@@ -131,7 +131,7 @@ identity-providers:
 `
 	var conf config.Config
 	err := yaml.Unmarshal([]byte(input), &conf)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(conf.IdentityProviders, gc.HasLen, 1)
 	c.Assert(conf.IdentityProviders[0].Name(), gc.Equals, "openstack2")
 }

--- a/idp/ldap/ldap_test.go
+++ b/idp/ldap/ldap_test.go
@@ -150,7 +150,7 @@ func (s *ldapSuite) getSampleParams() ldap.Params {
 
 func (s *ldapSuite) setupIdp(c *gc.C, params ldap.Params, db ldapDB) idp.IdentityProvider {
 	i, err := ldap.NewIdentityProvider(params)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	s.ldapDialer = newMockLDAPDialer(db)
 	ldap.SetLDAP(i, s.ldapDialer.Dial)
 	i.Init(context.TODO(), s.InitParams(c, "https://example.com/test"))
@@ -166,7 +166,7 @@ func (s *ldapSuite) makeLoginRequest(c *gc.C, i idp.IdentityProvider, username, 
 			}.Encode(),
 		),
 	)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.ParseForm()
 	rr := httptest.NewRecorder()

--- a/idp/static/static_test.go
+++ b/idp/static/static_test.go
@@ -53,7 +53,7 @@ func (s *staticSuite) makeLoginRequest(c *gc.C, i idp.IdentityProvider, username
 			}.Encode(),
 		),
 	)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.ParseForm()
 	rr := httptest.NewRecorder()

--- a/idp/test/test_test.go
+++ b/idp/test/test_test.go
@@ -40,7 +40,7 @@ identity-providers:
 `
 	var conf config.Config
 	err := yaml.Unmarshal([]byte(configYaml), &conf)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(conf.IdentityProviders, gc.HasLen, 1)
 	c.Assert(conf.IdentityProviders[0].Name(), gc.Equals, "test")
 }

--- a/idp/usso/internal/kvnoncestore/store_test.go
+++ b/idp/usso/internal/kvnoncestore/store_test.go
@@ -72,9 +72,9 @@ var acceptTests = []struct {
 
 func (s *storeSuite) TestAccept(c *gc.C) {
 	now, err := time.Parse(time.RFC3339, "2014-12-25T00:00:00Z")
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	err = kvnoncestore.Accept(s.store, "https://example.com", "2014-12-25T00:00:00Z0", now)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	for i, test := range acceptTests {
 		c.Logf("%d. %s", i, test.about)
 		err := kvnoncestore.Accept(s.store, test.endpoint, test.nonce, now)
@@ -82,6 +82,6 @@ func (s *storeSuite) TestAccept(c *gc.C) {
 			c.Assert(err, gc.ErrorMatches, test.expectError)
 			continue
 		}
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 	}
 }

--- a/idp/usso/usso_test.go
+++ b/idp/usso/usso_test.go
@@ -64,7 +64,7 @@ identity-providers:
 `
 	var conf config.Config
 	err := yaml.Unmarshal([]byte(configYaml), &conf)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(conf.IdentityProviders, gc.HasLen, 1)
 	c.Assert(conf.IdentityProviders[0].Name(), gc.Equals, "usso")
 }

--- a/idp/usso/ussodischarge/ussodischarge_test.go
+++ b/idp/usso/ussodischarge/ussodischarge_test.go
@@ -72,7 +72,7 @@ identity-providers:
 `
 	var conf config.Config
 	err := yaml.Unmarshal([]byte(configYaml), &conf)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(conf.IdentityProviders, gc.HasLen, 1)
 	c.Assert(conf.IdentityProviders[0].Name(), gc.Equals, "usso_macaroon")
 }

--- a/idp/usso/ussooauth/ussooauth_test.go
+++ b/idp/usso/ussooauth/ussooauth_test.go
@@ -58,7 +58,7 @@ identity-providers:
 `
 	var conf config.Config
 	err := yaml.Unmarshal([]byte(configYaml), &conf)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(conf.IdentityProviders, gc.HasLen, 1)
 	c.Assert(conf.IdentityProviders[0].Name(), gc.Equals, "usso_oauth")
 }
@@ -174,7 +174,7 @@ func (s *ussooauthSuite) TestHandleVerifyFail(c *gc.C) {
 		req.URL,
 		nil,
 	)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	rr := httptest.NewRecorder()
 	s.idp.Handle(s.Ctx, rr, req)
 	s.AssertLoginFailureMatches(c, `invalid OAuth credentials`)

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -163,7 +163,7 @@ func (s *authSuite) TestAuthorizeWithAdminCredentials(c *gc.C) {
 
 func (s *authSuite) TestUserHasPublicKeyCaveat(c *gc.C) {
 	key, err := bakery.GenerateKey()
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	cav := auth.UserHasPublicKeyCaveat(params.Username("test"), &key.Public)
 	c.Assert(cav.Namespace, gc.Equals, auth.CheckersNamespace)
 	c.Assert(cav.Condition, gc.Matches, "user-has-public-key test .*")
@@ -172,7 +172,7 @@ func (s *authSuite) TestUserHasPublicKeyCaveat(c *gc.C) {
 
 func (s *authSuite) TestUserHasPublicKeyChecker(c *gc.C) {
 	key, err := bakery.GenerateKey()
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	ctx, close := s.Store.Context(context.Background())
 	defer close()
 	s.createIdentity(c, "test-user", &key.Public)
@@ -185,7 +185,7 @@ func (s *authSuite) TestUserHasPublicKeyChecker(c *gc.C) {
 	}
 
 	err = checkCaveat(auth.UserHasPublicKeyCaveat(params.Username("test-user"), &key.Public))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	// Unknown username
 	err = checkCaveat(auth.UserHasPublicKeyCaveat("test2", &key.Public))
 	c.Assert(err, gc.ErrorMatches, "caveat.*not satisfied: public key not valid for user")
@@ -268,7 +268,7 @@ func (s *authSuite) TestACLForOp(c *gc.C) {
 		c.Logf("test %d: %v", i, test.op)
 		sort.Strings(test.expect)
 		acl, public, err := auth.AuthorizerACLForOp(s.authorizer, context.Background(), test.op)
-		c.Assert(err, gc.IsNil)
+		c.Assert(err, gc.Equals, nil)
 		sort.Strings(acl)
 		c.Assert(acl, gc.DeepEquals, test.expect)
 		c.Assert(public, gc.Equals, test.expectPublic)
@@ -278,7 +278,7 @@ func (s *authSuite) TestACLForOp(c *gc.C) {
 func (s *authSuite) TestAdminUserGroups(c *gc.C) {
 	ctx := auth.ContextWithUserCredentials(context.Background(), "admin", "password")
 	authInfo, err := s.authorizer.Auth(ctx, nil, identchecker.LoginOp)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	assertAuthorizedGroups(c, authInfo, nil)
 }
 
@@ -306,7 +306,7 @@ func assertAuthorizedGroups(c *gc.C, authInfo *identchecker.AuthInfo, expectGrou
 	c.Assert(authInfo.Identity, gc.NotNil)
 	ident := authInfo.Identity.(*auth.Identity)
 	groups, err := ident.Groups(context.Background())
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(groups, gc.DeepEquals, expectGroups)
 }
 

--- a/internal/auth/httpauth/httpauth_test.go
+++ b/internal/auth/httpauth/httpauth_test.go
@@ -125,7 +125,7 @@ func (s *authSuite) TestAuthorizeMacaroonRequired(c *gc.C) {
 	})
 	httpAuthorizer := httpauth.New(s.oven, authorizer)
 	req, err := http.NewRequest("GET", "http://example.com/v1/test", nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	authInfo, err := httpAuthorizer.Auth(context.Background(), req, identchecker.LoginOp)
 	c.Assert(err, gc.ErrorMatches, `macaroon discharge required: authentication required`)
 	c.Assert(authInfo, gc.IsNil)

--- a/internal/debug/debug_test.go
+++ b/internal/debug/debug_test.go
@@ -93,7 +93,7 @@ func (s *debugSuite) TestServeDebugStatus(c *gc.C) {
 		ExpectBody: httptesting.BodyAsserter(func(c *gc.C, body json.RawMessage) {
 			var result map[string]debugstatus.CheckResult
 			err := json.Unmarshal(body, &result)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			c.Assert(result, gc.HasLen, len(expectNames))
 			for k, v := range result {
 				c.Assert(v.Name, gc.Equals, expectNames[k], gc.Commentf("%s: incorrect name", k))

--- a/internal/debug/login_test.go
+++ b/internal/debug/login_test.go
@@ -75,9 +75,9 @@ func (s *loginSuite) TestCookieEncodeDecode(c *gc.C) {
 		Teams:      []string{"t1", "t2"},
 	}
 	v, err := debug.EncodeCookie(s.Params.Key, c1)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 	c2, err := debug.DecodeCookie(s.Params.Key, v)
-	c.Assert(err, jc.ErrorIsNil)
+	c.Assert(err, gc.Equals, nil)
 	c.Assert(c1.ExpireTime.Equal(c1.ExpireTime), gc.Equals, true, gc.Commentf("expire times not equal expecting: %s, obtained: %s", c1.ExpireTime, c2.ExpireTime))
 	c1.ExpireTime = time.Time{}
 	c2.ExpireTime = time.Time{}
@@ -169,7 +169,7 @@ func (s *loginSuite) TestCheckLogin(c *gc.C) {
 		var cookies []*http.Cookie
 		if test.cookieValue != nil {
 			value, err := test.cookieValue(s.Params.Key)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			cookies = append(cookies, &http.Cookie{
 				Name:  "debug-login",
 				Value: value,

--- a/internal/discharger/discharge_test.go
+++ b/internal/discharger/discharge_test.go
@@ -520,7 +520,7 @@ func (s *dischargeSuite) TestDischargeStatusProxyAuthRequiredResponse(c *gc.C) {
 		}},
 		identchecker.LoginOp,
 	)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	var thirdPartyCaveat macaroon.Caveat
 	for _, cav := range m.M().Caveats() {
@@ -534,7 +534,7 @@ func (s *dischargeSuite) TestDischargeStatusProxyAuthRequiredResponse(c *gc.C) {
 		"id":       {string(thirdPartyCaveat.Id)},
 		"location": {thirdPartyCaveat.Location},
 	})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer resp.Body.Close()
 
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusProxyAuthRequired)
@@ -553,7 +553,7 @@ func (s *dischargeSuite) TestDischargeStatusUnauthorizedResponse(c *gc.C) {
 		}},
 		identchecker.LoginOp,
 	)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 
 	var thirdPartyCaveat macaroon.Caveat
 	for _, cav := range m.M().Caveats() {
@@ -569,11 +569,11 @@ func (s *dischargeSuite) TestDischargeStatusUnauthorizedResponse(c *gc.C) {
 	}
 
 	req, err := http.NewRequest("POST", s.URL+"/discharge", strings.NewReader(values.Encode()))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Bakery-Protocol-Version", "1")
 	resp, err := http.DefaultClient.Do(req)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer resp.Body.Close()
 
 	c.Assert(resp.StatusCode, gc.Equals, http.StatusUnauthorized)
@@ -582,7 +582,7 @@ func (s *dischargeSuite) TestDischargeStatusUnauthorizedResponse(c *gc.C) {
 
 func (s *dischargeSuite) TestPublicKey(c *gc.C) {
 	info, err := s.ThirdPartyInfo(testContext, s.URL)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		URL:          s.URL + "/publickey",
 		ExpectStatus: http.StatusOK,
@@ -709,7 +709,7 @@ func (s *dischargeSuite) TestDomainInInteractionURLs(c *gc.C) {
 		interactor.Doer = client
 		for k, v := range tst.cookies {
 			u, err := url.Parse(s.URL)
-			c.Assert(err, gc.IsNil)
+			c.Assert(err, gc.Equals, nil)
 			client.Jar.SetCookies(u, []*http.Cookie{{
 				Name:  k,
 				Value: v,

--- a/internal/identity/server_test.go
+++ b/internal/identity/server_test.go
@@ -68,7 +68,7 @@ func (s *serverSuite) TestNewServerWithVersions(c *gc.C) {
 					}
 					enc := json.NewEncoder(w)
 					err := enc.Encode(response)
-					c.Assert(err, gc.IsNil)
+					c.Assert(err, gc.Equals, nil)
 				},
 			}}, nil
 		}
@@ -81,7 +81,7 @@ func (s *serverSuite) TestNewServerWithVersions(c *gc.C) {
 	}, map[string]identity.NewAPIHandlerFunc{
 		"version1": serveVersion("version1"),
 	})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer h.Close()
 	assertServesVersion(c, h, "version1")
 	assertDoesNotServeVersion(c, h, "version2")
@@ -95,7 +95,7 @@ func (s *serverSuite) TestNewServerWithVersions(c *gc.C) {
 		"version1": serveVersion("version1"),
 		"version2": serveVersion("version2"),
 	})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer h.Close()
 	assertServesVersion(c, h, "version1")
 	assertServesVersion(c, h, "version2")
@@ -110,7 +110,7 @@ func (s *serverSuite) TestNewServerWithVersions(c *gc.C) {
 		"version2": serveVersion("version2"),
 		"version3": serveVersion("version3"),
 	})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer h.Close()
 	assertServesVersion(c, h, "version1")
 	assertServesVersion(c, h, "version2")
@@ -134,7 +134,7 @@ func (s *serverSuite) TestServerHasAccessControlAllowHeaders(c *gc.C) {
 		MeetingStore: s.MeetingStore,
 		ACLStore:     s.ACLStore,
 	}, impl)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer h.Close()
 	rec := httptesting.DoRequest(c, httptesting.DoRequestParams{
 		Handler: h,
@@ -181,7 +181,7 @@ func (s *serverSuite) TestServerPanicRecovery(c *gc.C) {
 		MeetingStore: s.MeetingStore,
 		ACLStore:     s.ACLStore,
 	}, impl)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer h.Close()
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
 		Handler:      h,
@@ -209,7 +209,7 @@ func (s *serverSuite) TestServerStaticFiles(c *gc.C) {
 					}
 					enc := json.NewEncoder(w)
 					err := enc.Encode(response)
-					c.Assert(err, gc.IsNil)
+					c.Assert(err, gc.Equals, nil)
 				},
 			}}, nil
 		}
@@ -223,17 +223,17 @@ func (s *serverSuite) TestServerStaticFiles(c *gc.C) {
 	}, map[string]identity.NewAPIHandlerFunc{
 		"version1": serveVersion("version1"),
 	})
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer h.Close()
 
 	f, err := os.Create(filepath.Join(path, "file"))
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	fmt.Fprintf(f, "test file")
 	f.Close()
 
 	rr := httptest.NewRecorder()
 	req, err := http.NewRequest("GET", "/static/file", nil)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	h.ServeHTTP(rr, req)
 	c.Assert(rr.Code, gc.Equals, http.StatusOK, gc.Commentf("%d: %s", rr.Code, rr.Body.String()))
 	c.Assert(rr.Body.String(), gc.Equals, "test file")

--- a/server_test.go
+++ b/server_test.go
@@ -72,7 +72,7 @@ func (s *serverSuite) TestNewServerWithVersions(c *gc.C) {
 		},
 		candid.Debug,
 	)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	defer h.Close()
 
 	httptesting.AssertJSONCall(c, httptesting.JSONCallParams{
@@ -87,7 +87,7 @@ func (s *serverSuite) TestNewServerWithVersions(c *gc.C) {
 func (s *serverSuite) TestNewServerRemovesAgentIDP(c *gc.C) {
 	var conf config.Config
 	err := yaml.Unmarshal([]byte(`{"identity-providers": [{"type":"agent"},{"type":"test","name":"test"}]}`), &conf)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	idps := make([]idp.IdentityProvider, len(conf.IdentityProviders))
 	for i, idp := range conf.IdentityProviders {
 		idps[i] = idp.IdentityProvider
@@ -105,7 +105,7 @@ func (s *serverSuite) TestNewServerRemovesAgentIDP(c *gc.C) {
 		},
 		candid.V1,
 	)
-	c.Assert(err, gc.IsNil)
+	c.Assert(err, gc.Equals, nil)
 	h.Close()
 }
 


### PR DESCRIPTION
This avoids doing those changes in every quicktest PR.
