### PR TITLE
use SNAP_DATA instead of SNAP_COMMON for config files

### DIFF
--- a/snap/local/wrappers/candidsrv
+++ b/snap/local/wrappers/candidsrv
@@ -1,7 +1,7 @@
 #!/bin/bash -eu
 
-CONFIG_FILE="${SNAP_COMMON}/config.yaml"
-ADMIN_AGENT_FILE="${SNAP_COMMON}/admin.keys"
+CONFIG_FILE="${SNAP_DATA}/config.yaml"
+ADMIN_AGENT_FILE="${SNAP_DATA}/admin.keys"
 
 if [ ! -e "$CONFIG_FILE" ]; then
     cp "${SNAP}/config/config.yaml" "$CONFIG_FILE"


### PR DESCRIPTION
Using SNAP_DATA for config files is more correct, as they might depend on the reviision on the snap.