### PR TITLE
snap: fix path config path in wrapper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The easiest way to start using the candid service is with the snap:
     snap install candid --edge
 
 The configuration file used by the snap can be found in
-`/var/snap/candid/common/config.yaml`.
+`/var/snap/candid/current/config.yaml`.
 
 ## Development
 

--- a/snap/local/wrappers/candid
+++ b/snap/local/wrappers/candid
@@ -1,5 +1,5 @@
 #!/bin/sh -eu
-url=$(grep ^location /var/snap/candid/common/config.yaml | cut -d: -f2- | sed "s/[ '\"]//g" || true)
+url=$(grep ^location /var/snap/candid/current/config.yaml | cut -d: -f2- | sed "s/[ '\"]//g" || true)
 
 if [ -z "${CANDID_URL:-}" ] && [ -n "${url}" ]; then
     export CANDID_URL=${url}


### PR DESCRIPTION
Fix leftover paths pointing to `/common/` rather than `/current/`