### PR TITLE
internal/discharge: Make all interactive logins redirect based.

### DIFF
--- a/idp/idp.go
+++ b/idp/idp.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon-bakery.v2/httpbakery"
 
+	"github.com/CanonicalLtd/candid/idp/idputil/secret"
 	"github.com/CanonicalLtd/candid/store"
 )
 
@@ -58,8 +59,9 @@ type InitParams struct {
 	// provider to mint new macaroons.
 	Oven *bakery.Oven
 
-	// Key contains the identity server's public/private key pair.
-	Key *bakery.KeyPair
+	// Codec contains the codec used to encode/decode session cookies
+	// in the login flow.
+	Codec *secret.Codec
 
 	// URLPrefix contains the prefix of all requests to the Handle
 	// method. The URL.Path parameter in the request passed to handle
@@ -107,10 +109,12 @@ type IdentityProvider interface {
 
 	// URL returns the URL to use to attempt a login with this
 	// identity provider. If the identity provider is interactive
-	// then the user will be automatically redirected to the URL.
-	// Otherwise the URL is returned in the response to a
-	// request for login methods.
-	URL(dischargeID string) string
+	// then the user will be redirected to the URL. Otherwise the URL
+	// is returned in the response to a request for login methods.
+	// The given state value should be round-tripped through the
+	// login interaction and used to verify the login when it
+	// completes.
+	URL(state string) string
 
 	// SetInteraction adds interaction information for this identity
 	// provider to the given interaction required error.

--- a/idp/idptest/client.go
+++ b/idp/idptest/client.go
@@ -1,0 +1,76 @@
+// Copyright 2015 Canonical Ltd.
+// Licensed under the AGPLv3, see LICENCE file for details.
+
+package idptest
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+
+	errgo "gopkg.in/errgo.v1"
+
+	"github.com/CanonicalLtd/candid/idp"
+	"github.com/CanonicalLtd/candid/idp/idputil"
+	"github.com/CanonicalLtd/candid/idp/idputil/secret"
+)
+
+// A Client allows tests to simulate sending HTTP requests to an IDP.
+type Client struct {
+	idp        idp.IdentityProvider
+	codec      *secret.Codec
+	loginState *http.Cookie
+	state      string
+}
+
+// NewClient create a new client for the given IDP.
+func NewClient(idp idp.IdentityProvider, codec *secret.Codec) *Client {
+	return &Client{
+		idp:   idp,
+		codec: codec,
+	}
+}
+
+// SetLoginStatus sets a login status that will be added to every
+// request.
+func (c *Client) SetLoginState(state idputil.LoginState) {
+	value, err := c.codec.Encode(state)
+	if err != nil {
+		panic(err)
+	}
+	c.loginState = &http.Cookie{
+		Name:  idputil.LoginCookieName,
+		Value: value,
+	}
+	rawValue, err := base64.URLEncoding.DecodeString(value)
+	if err != nil {
+		panic(err)
+	}
+	hash := sha256.Sum256(rawValue)
+	c.state = base64.RawURLEncoding.EncodeToString(hash[:])
+}
+
+// Do simulates a round trip to the idp handler.
+func (c *Client) Do(req *http.Request) (*http.Response, error) {
+	if c.loginState != nil {
+		v := req.URL.Query()
+		v.Set("state", c.state)
+		req.URL.RawQuery = v.Encode()
+		req.AddCookie(c.loginState)
+	}
+	req.ParseForm()
+	w := httptest.NewRecorder()
+	c.idp.Handle(context.Background(), w, req)
+	return w.Result(), nil
+}
+
+// Get simulates a get request on the idp handler.
+func (c *Client) Get(url string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, errgo.Mask(err)
+	}
+	return c.Do(req)
+}

--- a/idp/idptest/suite.go
+++ b/idp/idptest/suite.go
@@ -5,14 +5,27 @@ package idptest
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"html/template"
 	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"time"
 
 	qt "github.com/frankban/quicktest"
+	"github.com/juju/qthttptest"
 	"github.com/juju/simplekv"
+	"gopkg.in/CanonicalLtd/candidclient.v1/params"
+	errgo "gopkg.in/errgo.v1"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon-bakery.v2/httpbakery"
 
 	"github.com/CanonicalLtd/candid/idp"
+	"github.com/CanonicalLtd/candid/idp/idputil"
+	"github.com/CanonicalLtd/candid/idp/idputil/secret"
 	"github.com/CanonicalLtd/candid/internal/candidtest"
 	"github.com/CanonicalLtd/candid/store"
 )
@@ -24,6 +37,9 @@ type Fixture struct {
 	// for store methods.
 	Ctx context.Context
 
+	// Codec contains a codec that will be passed in the idp.InitParams.
+	Codec *secret.Codec
+
 	// Oven contains a bakery.Oven that will be passed in the
 	// idp.InitParams. Tests can use this to mint macaroons if
 	// necessary.
@@ -31,6 +47,9 @@ type Fixture struct {
 
 	// Store holds the store used by the fixture.
 	Store *candidtest.Store
+
+	// Template holds the template to use for generating pages
+	Template *template.Template
 
 	dischargeTokenCreator *dischargeTokenCreator
 	visitCompleter        *visitCompleter
@@ -54,8 +73,10 @@ func NewFixture(c *qt.C, store *candidtest.Store) *Fixture {
 	c.Assert(err, qt.Equals, nil)
 	return &Fixture{
 		Ctx:                   ctx,
+		Codec:                 secret.NewCodec(key),
 		Oven:                  oven,
 		Store:                 store,
+		Template:              candidtest.DefaultTemplate,
 		dischargeTokenCreator: &dischargeTokenCreator{},
 		visitCompleter: &visitCompleter{
 			c: c,
@@ -71,12 +92,96 @@ func (s *Fixture) InitParams(c *qt.C, prefix string) idp.InitParams {
 		Store:                 s.Store.Store,
 		KeyValueStore:         s.kvStore,
 		Oven:                  s.Oven,
-		Key:                   s.Oven.Key(),
+		Codec:                 s.Codec,
 		URLPrefix:             prefix,
 		DischargeTokenCreator: s.dischargeTokenCreator,
 		VisitCompleter:        s.visitCompleter,
-		Template:              candidtest.DefaultTemplate,
+		Template:              s.Template,
 	}
+}
+
+// LoginState creates a candid-login with the given login state.
+func (s *Fixture) LoginState(c *qt.C, state idputil.LoginState) (*http.Cookie, string) {
+	value, err := s.Codec.Encode(state)
+	c.Assert(err, qt.Equals, nil)
+	rawValue, err := base64.URLEncoding.DecodeString(value)
+	c.Assert(err, qt.Equals, nil)
+	hash := sha256.Sum256(rawValue)
+	return &http.Cookie{
+		Name:  idputil.LoginCookieName,
+		Value: value,
+	}, base64.RawURLEncoding.EncodeToString(hash[:])
+}
+
+// Client creates an HTTP client that will replace the given prefix with
+// the given replacement in all request URLs. The client will also stop
+// redirecting and return the last response when a request with the given
+// stopPrefix is attempted.
+func (s *Fixture) Client(c *qt.C, prefix, replacement, stopPrefix string) *http.Client {
+	jar, err := cookiejar.New(nil)
+	c.Assert(err, qt.Equals, nil)
+	return &http.Client{
+		Transport: qthttptest.URLRewritingTransport{
+			MatchPrefix:  prefix,
+			Replace:      replacement,
+			RoundTripper: http.DefaultTransport,
+		},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if strings.HasPrefix(req.URL.String(), stopPrefix) {
+				return http.ErrUseLastResponse
+			}
+			return nil
+		},
+		Jar: jar,
+	}
+}
+
+// ParseResponse parses a store.Identity from the given HTTP response.
+func (s *Fixture) ParseResponse(c *qt.C, resp *http.Response) (*store.Identity, error) {
+	c.Assert(resp.StatusCode, qt.Equals, http.StatusSeeOther)
+	ru, err := url.Parse(resp.Header.Get("Location"))
+	c.Assert(err, qt.Equals, nil)
+	rv := ru.Query()
+	if msg := rv.Get("error"); msg != "" {
+		if code := rv.Get("error_code"); code != "" {
+			return nil, errgo.WithCausef(nil, params.ErrorCode(code), "%s", msg)
+		}
+		return nil, errgo.New(msg)
+	}
+	c.Assert(rv.Get("code"), qt.Equals, "6789")
+	return s.visitCompleter.id, nil
+}
+
+// DoInteractiveLogin performs a full interactive login cycle with the
+// given IDP.
+func (s *Fixture) DoInteractiveLogin(c *qt.C, idp idp.IdentityProvider, loginURL string, f func(*http.Client, *http.Response) (*http.Response, error)) (*store.Identity, error) {
+	u, err := url.Parse(loginURL)
+	c.Assert(err, qt.Equals, nil)
+	hu := *u
+	hu.Path = ""
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		req.ParseForm()
+		idp.Handle(req.Context(), w, req)
+	}))
+	defer srv.Close()
+	client := s.Client(c, hu.String(), srv.URL, "http://result.example.com")
+	cookie, state := s.LoginState(c, idputil.LoginState{
+		ReturnTo: "http://result.example.com/callback",
+		State:    "1234",
+		Expires:  time.Now().Add(10 * time.Minute),
+	})
+	client.Jar.SetCookies(&hu, []*http.Cookie{cookie})
+	v := u.Query()
+	v.Set("state", state)
+	u.RawQuery = v.Encode()
+	resp, err := client.Get(u.String())
+	c.Assert(err, qt.Equals, nil)
+	if f != nil {
+		resp, err = f(client, resp)
+		c.Assert(err, qt.Equals, nil)
+	}
+	defer resp.Body.Close()
+	return s.ParseResponse(c, resp)
 }
 
 // AssertLoginSuccess asserts that the login test has resulted in a
@@ -88,11 +193,37 @@ func (s *Fixture) AssertLoginSuccess(c *qt.C, username string) {
 	c.Assert(s.visitCompleter.id.Username, qt.Equals, username)
 }
 
-// AssertLoginFailure asserts that the login test has resulted in a
+// AssertLoginRedirectSuccess asserts that the given redirect URL is for
+// a successful login of the given user.
+func (s *Fixture) AssertLoginRedirectSuccess(c *qt.C, rurl, returnTo, state string, username string) {
+	u, err := url.Parse(rurl)
+	c.Assert(err, qt.Equals, nil)
+	v := u.Query()
+	u.RawQuery = ""
+	c.Assert(u.String(), qt.Equals, returnTo)
+	c.Assert(v.Get("state"), qt.Equals, state)
+	c.Assert(v.Get("code"), qt.Equals, "6789")
+	c.Assert(s.visitCompleter.id.Username, qt.Equals, username)
+}
+
+// AssertLoginFailureMatches asserts that the login test has resulted in a
 // failure with an error that matches the given regex.
 func (s *Fixture) AssertLoginFailureMatches(c *qt.C, regex string) {
 	c.Assert(s.visitCompleter.called, qt.Equals, true)
 	c.Assert(s.visitCompleter.err, qt.ErrorMatches, regex)
+}
+
+// AssertLoginRedirectFailureMatches asserts that the login test has resulted in a
+// failure with an error that matches the given regex.
+func (s *Fixture) AssertLoginRedirectFailureMatches(c *qt.C, rurl, returnTo, state, errorCode, regex string) {
+	u, err := url.Parse(rurl)
+	c.Assert(err, qt.Equals, nil)
+	v := u.Query()
+	u.RawQuery = ""
+	c.Assert(u.String(), qt.Equals, returnTo)
+	c.Assert(v.Get("state"), qt.Equals, state)
+	c.Assert(v.Get("error_code"), qt.Equals, errorCode)
+	c.Assert(v.Get("error"), qt.ErrorMatches, regex)
 }
 
 // AssertLoginNotComplete asserts that the login attempt has not yet
@@ -105,8 +236,6 @@ type visitCompleter struct {
 	c           *qt.C
 	called      bool
 	dischargeID string
-	returnTo    string
-	state       string
 	id          *store.Identity
 	err         error
 }
@@ -131,26 +260,50 @@ func (l *visitCompleter) Failure(_ context.Context, _ http.ResponseWriter, _ *ht
 	l.err = err
 }
 
-func (l *visitCompleter) RedirectSuccess(_ context.Context, _ http.ResponseWriter, _ *http.Request, returnTo, state string, id *store.Identity) {
+// RedirectSuccess implements isp.VisitCompleter.RedirectSuccess.
+func (l *visitCompleter) RedirectSuccess(_ context.Context, w http.ResponseWriter, req *http.Request, returnTo, state string, id *store.Identity) {
 	if l.called {
 		l.c.Error("login completion method called more than once")
 		return
 	}
-	l.called = true
-	l.returnTo = returnTo
-	l.state = state
 	l.id = id
+	u, err := url.Parse(returnTo)
+	if err != nil {
+		l.c.Error(err)
+		return
+	}
+	v := u.Query()
+	v.Set("state", state)
+	v.Set("code", "6789")
+	u.RawQuery = v.Encode()
+	http.Redirect(w, req, u.String(), http.StatusSeeOther)
 }
 
-func (l *visitCompleter) RedirectFailure(_ context.Context, _ http.ResponseWriter, _ *http.Request, returnTo, state string, err error) {
+// RedirectFailure implements isp.VisitCompleter.RedirectFailure.
+func (l *visitCompleter) RedirectFailure(_ context.Context, w http.ResponseWriter, req *http.Request, returnTo, state string, verr error) {
 	if l.called {
 		l.c.Error("login completion method called more than once")
 		return
 	}
 	l.called = true
-	l.returnTo = returnTo
-	l.state = state
-	l.err = err
+
+	u, err := url.Parse(returnTo)
+	if err != nil {
+		l.c.Error(err)
+		return
+	}
+	v := u.Query()
+	v.Set("state", state)
+	v.Set("error", verr.Error())
+	if ec, ok := errgo.Cause(verr).(errorCoder); ok {
+		v.Set("error_code", string(ec.ErrorCode()))
+	}
+	u.RawQuery = v.Encode()
+	http.Redirect(w, req, u.String(), http.StatusSeeOther)
+}
+
+type errorCoder interface {
+	ErrorCode() params.ErrorCode
 }
 
 type dischargeTokenCreator struct{}

--- a/idp/keystone/common_test.go
+++ b/idp/keystone/common_test.go
@@ -14,6 +14,8 @@ import (
 	"github.com/CanonicalLtd/candid/internal/candidtest"
 )
 
+const idpPrefix = "https://idp.example.com"
+
 type fixture struct {
 	idptest *idptest.Fixture
 	server  *mockkeystone.Server
@@ -50,7 +52,7 @@ func newFixture(c *qt.C, p fixtureParams) *fixture {
 	s.server.TenantsFunc = p.tenantsFunc
 	s.server.UserGroupsFunc = p.userGroupsFunc
 	s.idp = p.newIDP(s.params)
-	err := s.idp.Init(s.idptest.Ctx, s.idptest.InitParams(c, "https://idp.test"))
+	err := s.idp.Init(s.idptest.Ctx, s.idptest.InitParams(c, idpPrefix))
 	c.Assert(err, qt.Equals, nil)
 	return s
 }

--- a/idp/ldap/ldap.go
+++ b/idp/ldap/ldap.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"text/template"
 
+	"github.com/juju/loggo"
 	"gopkg.in/CanonicalLtd/candidclient.v1/params"
 	"gopkg.in/errgo.v1"
 	"gopkg.in/ldap.v2"
@@ -26,6 +27,8 @@ import (
 	"github.com/CanonicalLtd/candid/idp/idputil"
 	"github.com/CanonicalLtd/candid/store"
 )
+
+var logger = loggo.GetLogger("candid.idp.ldap")
 
 func init() {
 	idp.Register("ldap", func(unmarshal func(interface{}) error) (idp.IdentityProvider, error) {
@@ -219,8 +222,8 @@ func (idp *identityProvider) Init(ctx context.Context, params idp.InitParams) er
 }
 
 // URL implements idp.IdentityProvider.URL.
-func (idp *identityProvider) URL(dischargeID string) string {
-	return idputil.URL(idp.initParams.URLPrefix, "/login", dischargeID)
+func (idp *identityProvider) URL(state string) string {
+	return idputil.RedirectURL(idp.initParams.URLPrefix, "/login", state)
 }
 
 // URL implements idp.IdentityProvider.SetInteraction.
@@ -266,15 +269,21 @@ func (idp *identityProvider) GetGroups(ctx context.Context, identity *store.Iden
 
 // Handle implements idp.IdentityProvider.Handle.
 func (idp *identityProvider) Handle(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	var ls idputil.LoginState
+	if err := idp.initParams.Codec.Cookie(req, idputil.LoginCookieName, req.Form.Get("state"), &ls); err != nil {
+		logger.Infof("Invalid login state: %s", err)
+		idputil.BadRequestf(w, "Login failed: invalid login state")
+		return
+	}
 	switch strings.TrimPrefix(req.URL.Path, idp.initParams.URLPrefix) {
 	case "/login":
-		if err := idp.handleLogin(ctx, w, req); err != nil {
-			idp.initParams.VisitCompleter.Failure(ctx, w, req, idputil.DischargeID(req), err)
+		if err := idp.handleLogin(ctx, w, req, ls); err != nil {
+			idp.initParams.VisitCompleter.RedirectFailure(ctx, w, req, ls.ReturnTo, ls.State, err)
 		}
 	}
 }
 
-func (idp *identityProvider) handleLogin(ctx context.Context, w http.ResponseWriter, req *http.Request) error {
+func (idp *identityProvider) handleLogin(ctx context.Context, w http.ResponseWriter, req *http.Request, ls idputil.LoginState) error {
 	switch req.Method {
 	default:
 		return errgo.WithCausef(nil, params.ErrBadRequest, "unsupported method %q", req.Method)
@@ -285,7 +294,7 @@ func (idp *identityProvider) handleLogin(ctx context.Context, w http.ResponseWri
 		if err != nil {
 			return err
 		}
-		idp.initParams.VisitCompleter.Success(ctx, w, req, idputil.DischargeID(req), id)
+		idp.initParams.VisitCompleter.RedirectSuccess(ctx, w, req, ls.ReturnTo, ls.State, id)
 		return nil
 	}
 }

--- a/idp/usso/discharge_test.go
+++ b/idp/usso/discharge_test.go
@@ -4,12 +4,9 @@
 package usso_test
 
 import (
-	"net/http"
-	"net/url"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
-	"gopkg.in/errgo.v1"
 	"gopkg.in/macaroon-bakery.v2/httpbakery"
 
 	"github.com/CanonicalLtd/candid/idp"
@@ -46,24 +43,6 @@ func TestInteractiveDischarge(t *testing.T) {
 	})
 	ussoSrv.MockUSSO.SetLoginUser("test")
 	dischargeCreator.AssertDischarge(c, httpbakery.WebBrowserInteractor{
-		OpenWebBrowser: visitWebPage(c),
+		OpenWebBrowser: candidtest.OpenWebBrowser(c, candidtest.SelectInteractiveLogin(nil)),
 	})
-}
-
-func visitWebPage(c *qt.C) func(u *url.URL) error {
-	return func(u *url.URL) error {
-		c.Logf("visiting %s", u)
-		client := http.Client{}
-		resp, err := client.Get(u.String())
-		if err != nil {
-			c.Logf("error: %s", err)
-			return err
-		}
-		defer resp.Body.Close()
-		c.Logf("status %s", resp.Status)
-		if resp.StatusCode != http.StatusOK {
-			return errgo.Newf("bad status %q", resp.Status)
-		}
-		return nil
-	}
 }

--- a/internal/candidtest/server.go
+++ b/internal/candidtest/server.go
@@ -14,7 +14,7 @@ import (
 	qt "github.com/frankban/quicktest"
 	aclstore "github.com/juju/aclstore/v2"
 	"github.com/juju/simplekv/memsimplekv"
-	"gopkg.in/CanonicalLtd/candidclient.v1"
+	candidclient "gopkg.in/CanonicalLtd/candidclient.v1"
 	errgo "gopkg.in/errgo.v1"
 	"gopkg.in/macaroon-bakery.v2/bakery"
 	"gopkg.in/macaroon-bakery.v2/httpbakery"
@@ -28,13 +28,16 @@ import (
 var DefaultTemplate = template.New("")
 
 func init() {
+	template.Must(DefaultTemplate.New("authentication-required").Parse(authenticationRequiredTemplate))
 	template.Must(DefaultTemplate.New("login").Parse(loginTemplate))
 	template.Must(DefaultTemplate.New("login-form").Parse(loginFormTemplate))
 }
 
 const (
-	loginTemplate     = "login successful as user {{.Username}}\n"
-	loginFormTemplate = "{{.Action}}\n"
+	// This format is interpretted by SelectInteractiveLogin.
+	authenticationRequiredTemplate = "{{range .IDPs}}{{.URL}}\n{{end}}"
+	loginTemplate                  = "login successful as user {{.Username}}\n"
+	loginFormTemplate              = "{{.Action}}\n"
 )
 
 // Server implements a test fixture that contains a candid server.

--- a/templates/authentication-required
+++ b/templates/authentication-required
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Authentication Required</title>
+</head>
+<body>
+  <h1>Authentication Required</h1>
+  <p>Please authenticate using one of the following:</p>
+  <ul>
+{{ range .IDPs }}
+    <li><a href="{{.URL}}">{{.Description}}</a></li>
+{{ end }}
+  </ul>
+</body>
+</html>


### PR DESCRIPTION
All web-browser based logins are now based around using redirects. The
wait based mechanisms are still supported using handlers wrapped
around the redirection.