### PR TITLE
idp/usso/ussodischarge: allow more than one login

### DIFF
--- a/idp/idptest/suite.go
+++ b/idp/idptest/suite.go
@@ -315,6 +315,13 @@ func (l *visitCompleter) RedirectFailure(_ context.Context, w http.ResponseWrite
 	http.Redirect(w, req, u.String(), http.StatusSeeOther)
 }
 
+func (f *Fixture) Reset() {
+	f.visitCompleter.called = false
+	f.visitCompleter.dischargeID = ""
+	f.visitCompleter.id = nil
+	f.visitCompleter.err = nil
+}
+
 type errorCoder interface {
 	ErrorCode() params.ErrorCode
 }


### PR DESCRIPTION
An over-zealous checker only allowed a maximum of one user to login
using the usso_macaroon method.