### PR TITLE
charm: fix candid.py: ep.adresses isn't callable, and peers.py: typo fix

### DIFF
--- a/charm/interfaces/candid/peers.py
+++ b/charm/interfaces/candid/peers.py
@@ -33,6 +33,6 @@ class CandidPeer(Endpoint):
         This list is de-duplicated and sorted by address, so it will be stable
         for change comparison.
         """
-        addrs = {u.recieved_raw['private-address']
+        addrs = {u.received_raw['private-address']
                  for u in self.all_joined_units}
         return list(sorted(addrs))

--- a/charm/layer-candid/reactive/candid.py
+++ b/charm/layer-candid/reactive/candid.py
@@ -66,7 +66,7 @@ def write_config_file():
             no_proxy = no_proxy[1:]
         ep = endpoint_from_flag('candid.connected')
         if ep:
-            no_proxy.extend(ep.addresses())
+            no_proxy.extend(ep.addresses)
         config["no-proxy"] = ",".join(no_proxy)
     if cc["identity-providers"]:
         try:


### PR DESCRIPTION
Fixes:
```
2020-01-14 09:34:13 DEBUG candid-relation-joined     no_proxy.extend(ep.addresses())                                                        
2020-01-14 09:34:13 DEBUG candid-relation-joined TypeError: 'list' object is not callable         
```                                          
 and:
```
2020-01-14 09:16:56 DEBUG candid-relation-joined     for u in self.all_joined_units}
2020-01-14 09:16:56 DEBUG candid-relation-joined AttributeError: 'RelatedUnit' object has no attribute 'recieved_raw'
```
